### PR TITLE
include inductor in import for eval & include in calculateCircuitLength

### DIFF
--- a/impedance/circuits.py
+++ b/impedance/circuits.py
@@ -1,6 +1,6 @@
 from .fitting import circuit_fit, buildCircuit, calculateCircuitLength
 from .plotting import plot_nyquist
-from .circuit_elements import R, C, W, A, E, G, s, p  # noqa: F401
+from .circuit_elements import R, C, L, W, A, E, G, s, p  # noqa: F401
 
 import numpy as np
 import os

--- a/impedance/fitting.py
+++ b/impedance/fitting.py
@@ -1,4 +1,4 @@
-from .circuit_elements import R, C, W, A, E, G, s, p  # noqa: F401
+from .circuit_elements import R, C, L, W, A, E, G, s, p  # noqa: F401
 import numpy as np
 from scipy.optimize import curve_fit
 
@@ -229,7 +229,7 @@ def buildCircuit(circuit, frequencies, *parameters, eval_string='', index=0):
 
 
 def calculateCircuitLength(circuit):
-    l1 = ['R', 'E', 'W', 'C', 'A', 'G']
+    l1 = ['R', 'E', 'W', 'C', 'L', 'A', 'G']
     length = 0
     for char in l1:
         length += circuit.count(char)


### PR DESCRIPTION
- includes `L` in `circuits.py` for use in eval str
- includes `L` in `fitting.py` and updated `calculateCircuitLength` to include 'L' when calculating length of the circuit string