### PR TITLE
add `draw_circuit` function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.14
 numpydoc
 nbsphinx
 scipy>=1.0
+schemdraw


### PR DESCRIPTION
Here's a function that can draw circuits based on string input.  It's a little rough right now, but I wanted to share the concept.

The function uses the [schemdraw](https://cdelker.bitbucket.io/SchemDraw/) package, which is well established and easy to use.  

Here are a couple of easy examples:

```
cstring= 'R_0-p(R_1,C_1)-p(R_2,C_2)-W_1/W_2'
d=draw_circuit(cstring)
```
![circuit1](https://user-images.githubusercontent.com/1451344/55677175-03570100-58b1-11e9-882a-320a956da23a.png)

```
cstring='R_0-C_1-L_4'
d=draw_circuit(cstring)
```
![circuit2](https://user-images.githubusercontent.com/1451344/55677182-1538a400-58b1-11e9-8a44-67cd2ae4b9d3.png)