### PR TITLE
Revert "Add non-ideal semi-infinite Warburg element"

### DIFF
--- a/impedance/circuit_elements.py
+++ b/impedance/circuit_elements.py
@@ -110,10 +110,6 @@ def W(p, f):
     where :math:`R` = p[0] (Ohms) and
     :math:`T` = p[1] (sec) = :math:`\\frac{L^2}{D}`
 
-        [1] S. Cruz-Manzo and P. Greenwood,
-        Journal of The Electrochemical Society, 166, A1176-A1184 (2019)
-        `doi:10.1149/2.0841906jes
-        <https://doi.org/10.1149/2.0841906jes>`_.
     """
     omega = 2*np.pi*np.array(f)
     Zw = np.vectorize(lambda y: p[0]/(np.sqrt(p[1]*1j*y) *
@@ -134,22 +130,6 @@ def A(p, f):
     omega = 2*np.pi*np.array(f)
     Aw = p[0]
     Zw = Aw*(1-1j)/np.sqrt(omega)
-    return Zw
-
-
-@element_metadata(num_params=2, units=['Ohm sec^-a', ''])
-def B(p, f):
-    """ defines a semi-infinite Warburg frequency element
-
-    Notes
-    -----
-    .. math::
-
-        Z = \\frac{A_W}{\\() 2 \\pi f})^\\alpha (1-j)
-    """
-    omega = 2*np.pi*np.array(f)
-    Aw, alpha = p
-    Zw = Aw*(1-1j)/((omega)**alpha)
     return Zw
 
 

--- a/impedance/circuits.py
+++ b/impedance/circuits.py
@@ -1,7 +1,7 @@
 from .fitting import circuit_fit, buildCircuit
 from .fitting import calculateCircuitLength, check_and_eval
 from .plotting import plot_nyquist
-from .circuit_elements import R, C, L, W, A, B, E, G, T, s, p  # noqa: F401
+from .circuit_elements import R, C, L, W, A, E, G, T, s, p  # noqa: F401
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/impedance/fitting.py
+++ b/impedance/fitting.py
@@ -1,4 +1,4 @@
-from .circuit_elements import R, C, L, W, A, B, E, G, T, s, p  # noqa: F401
+from .circuit_elements import R, C, L, W, A, E, G, T, s, p  # noqa: F401
 import numpy as np
 from scipy.optimize import curve_fit
 
@@ -242,7 +242,7 @@ def buildCircuit(circuit, frequencies, *parameters,
 
 
 def calculateCircuitLength(circuit):
-    elements = [R, C, L, W, A, B, E, G, T]
+    elements = [R, C, L, W, A, E, G, T]
     length = 0
     for element in elements:
         num_params = element.num_params
@@ -251,7 +251,7 @@ def calculateCircuitLength(circuit):
 
 
 def check_and_eval(element):
-    allowed_elements = ['R', 'C', 'L', 'W', 'A', 'B', 'E', 'G', 'T']
+    allowed_elements = ['R', 'C', 'L', 'W', 'A', 'E', 'G', 'T']
     if element not in allowed_elements or len(element) != 1:
         raise ValueError
     else:


### PR DESCRIPTION
There's a few issues with this one still that need to be fixed before we merge it. In particular,

1. it looks like the reference was added to the incorrect element `W`, https://github.com/ECSHackWeek/impedance.py/blob/18a7920a8d322ff18836afbde27993c21396f85b/impedance/circuit_elements.py#L100-L121 instead of `B` https://github.com/ECSHackWeek/impedance.py/blob/18a7920a8d322ff18836afbde27993c21396f85b/impedance/circuit_elements.py#L140-L153 

2. A quick glance through the reference doesn't show the equation added in `B` (I think). I think it makes sense to either find a different reference or add the equation for blocked diffusion Warburg (Eq. 37) with frequency dispersion that's in this paper.

3. Any thoughts on a better naming scheme?