### PR TITLE
More plotting options in plot_nyquist

### DIFF
--- a/impedance/circuits.py
+++ b/impedance/circuits.py
@@ -213,7 +213,7 @@ class BaseCircuit:
         return to_print
 
     def plot(self, ax=None, f_data=None, Z_data=None,
-             conf_bounds=None, scale=1, units='Ohms'):
+             conf_bounds=None, scale=1, units='Ohms', **kwargs):
         """ a convenience method for plotting Nyquist plots
 
 
@@ -230,6 +230,12 @@ class BaseCircuit:
             randomly sampled parameter sets where each of the parameters is
             sampled from a normal distribution
 
+        Other Parameters
+        ----------------
+        **kwargs : `matplotlib.pyplot.Line2D` properties, optional
+            Used to specify line properties like linewidth, line color,
+            marker color, and line labels.
+
         Returns
         -------
         ax: matplotlib.axes
@@ -240,8 +246,8 @@ class BaseCircuit:
             fig, ax = plt.subplots(figsize=(5, 5))
 
         if Z_data is not None:
-            ax = plot_nyquist(ax, f_data, Z_data,
-                              scale=scale, units=units, fmt='s')
+            ax = plot_nyquist(ax, Z_data,
+                              scale=scale, units=units, fmt='s', **kwargs)
 
         if self._is_fit():
 
@@ -251,8 +257,8 @@ class BaseCircuit:
                 f_pred = np.logspace(5, -3)
 
             Z_fit = self.predict(f_pred)
-            ax = plot_nyquist(ax, f_data, Z_fit,
-                              scale=scale, units=units, fmt='s')
+            ax = plot_nyquist(ax, Z_fit,
+                              scale=scale, units=units, fmt='s', **kwargs)
 
             base_ylim, base_xlim = ax.get_ylim(), ax.get_xlim()
 

--- a/impedance/plotting.py
+++ b/impedance/plotting.py
@@ -15,7 +15,7 @@ class FixedOrderFormatter(ScalarFormatter):
         self.orderOfMagnitude = self._order_of_mag
 
 
-def plot_nyquist(ax, freq, Z, scale=1, units='Ohms', fmt='.-'):
+def plot_nyquist(ax, Z, scale=1, units='Ohms', fmt='.-', **kwargs):
     """ Convenience function for plotting nyquist plots
 
 
@@ -23,8 +23,6 @@ def plot_nyquist(ax, freq, Z, scale=1, units='Ohms', fmt='.-'):
         ----------
         ax: matplotlib.axes.Axes
             axes on which to plot the nyquist plot
-        freq: np.array of floats
-            frequencies
         Z: np.array of complex numbers
             impedance data
         scale: float
@@ -34,12 +32,18 @@ def plot_nyquist(ax, freq, Z, scale=1, units='Ohms', fmt='.-'):
         fmt: string
             format string passed to matplotlib (e.g. '.-' or 'o')
 
+        Other Parameters
+        ----------------
+        **kwargs : `matplotlib.pyplot.Line2D` properties, optional
+            Used to specify line properties like linewidth, line color,
+            marker color, and line labels.
+
         Returns
         -------
         ax: matplotlib.axes.Axes
     """
 
-    ax.plot(np.real(Z), -np.imag(Z), fmt, lw=3)
+    ax.plot(np.real(Z), -np.imag(Z), fmt, **kwargs)
 
     # Make the axes square
     ax.set_aspect('equal')

--- a/impedance/tests/test_circuits.py
+++ b/impedance/tests/test_circuits.py
@@ -29,8 +29,8 @@ def test_Randles():
 
     # check that plotting returns a plt.Axes() object
     _, ax = plt.subplots()
-    assert isinstance(randles.plot(ax, Z), type(ax))
-    assert isinstance(randles.plot(ax, Z,
+    assert isinstance(randles.plot(ax, frequencies, Z), type(ax))
+    assert isinstance(randles.plot(ax, frequencies, Z,
                                    conf_bounds='error_bars'), type(ax))
 
     # check that predicting impedance from fit works

--- a/impedance/tests/test_circuits.py
+++ b/impedance/tests/test_circuits.py
@@ -29,8 +29,8 @@ def test_Randles():
 
     # check that plotting returns a plt.Axes() object
     _, ax = plt.subplots()
-    assert isinstance(randles.plot(ax, frequencies, Z), type(ax))
-    assert isinstance(randles.plot(ax, frequencies, Z,
+    assert isinstance(randles.plot(ax, Z), type(ax))
+    assert isinstance(randles.plot(ax, Z,
                                    conf_bounds='error_bars'), type(ax))
 
     # check that predicting impedance from fit works

--- a/impedance/tests/test_plotting.py
+++ b/impedance/tests/test_plotting.py
@@ -5,11 +5,10 @@ from impedance.plotting import plot_nyquist
 
 def test_plot_nyquist():
 
-    frequencies = [1000.0, 1.0, 0.01]
     Z = np.array([1, 2, 3]) + 1j*np.array([2, 3, 4])
 
     _, ax = plt.subplots()
-    ax = plot_nyquist(ax, frequencies, Z)
+    ax = plot_nyquist(ax, Z)
 
     xs, ys = ax.lines[0].get_xydata().T
 


### PR DESCRIPTION
Added kwargs to plot_nyquist for matplotlib kwargs. Removed  arg from plot_nyquist and changed calls in other areas to reflect the change.

Addresses issue #73 