### PR TITLE
Removed printing of each fit Rs and ts in eval_linKK. 

### DIFF
--- a/impedance/validation.py
+++ b/impedance/validation.py
@@ -135,7 +135,6 @@ def eval_linKK(Rs, R0, ts, f):
     circuit_string = 's([R({},{}),'.format([R0], f.tolist())
 
     for (Rk, tk) in zip(Rs, ts):
-        print(Rk, tk)
         circuit_string += 'K({},{}),'.format([Rk, tk], f.tolist())
 
     circuit_string = circuit_string.strip(',')


### PR DESCRIPTION
This was left over from exploration in issue #69. It's a very minor change that doesn't significantly impact functionality.