### PR TITLE
Fix issue where test files were being counted in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = impedance/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
    - flake8 impedance --exclude=*.ipynb_checkpoints
 
 script:
-   - nosetests --with-coverage --cover-erase --cover-package=impedance
+   - pytest --cov=impedance impedance/tests
 
 after_success:
    - coverage report

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 altair>=3.0
 matplotlib>=3.0
-nose>=1.3
 numpy>=1.14
 numpydoc
 nbsphinx
+pytest
+pytest-cov
 scipy>=1.0


### PR DESCRIPTION
Switches from nose to pytest w/ pytest-cov. `impedance/tests/` are omitted via the .coveragerc file