### PR TITLE
require pytest >= 4.6 to avoid versioning conflict with pytest-cov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ matplotlib>=3.0
 numpy>=1.14
 numpydoc
 nbsphinx
-pytest
+pytest>=4.6
 pytest-cov
 scipy>=1.0


### PR DESCRIPTION
A versioning conflict was causing builds on Travis to fail. Fixes by requiring pytest >= 4.6 in our requirements.txt

```bash
$ pytest --cov=impedance impedance/tests

Traceback (most recent call last):

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/manager.py", line 267, in load_setuptools_entrypoints

    plugin = ep.load()

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2410, in load

    self.require(*args, **kwargs)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2433, in require

    items = working_set.resolve(reqs, env, installer, extras=self.extras)

  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pkg_resources/__init__.py", line 791, in resolve

    raise VersionConflict(dist, req).with_context(dependent_req)

pkg_resources.VersionConflict: (pytest 4.3.1 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('pytest>=4.6'))
```