### PR TITLE
Add logic to buildCircuit to catch single element circuits by checkin…

### DIFF
--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -202,6 +202,9 @@ def buildCircuit(circuit, frequencies, *parameters,
     elif parallel is not None and len(parallel) > 1:
         eval_string += "p(["
         split = parallel
+    elif series == parallel:
+        eval_string += "(["
+        split = series
 
     for i, elem in enumerate(split):
         if ',' in elem or '-' in elem:

--- a/impedance/tests/test_fitting.py
+++ b/impedance/tests/test_fitting.py
@@ -63,6 +63,15 @@ def test_buildCircuit():
         'p([C([0.2],[1000.0,5.0,0.01]),' + \
         'R([0.3],[1000.0,5.0,0.01])])])'
 
+    # Test single element circuit
+    circuit = 'R1'
+    params = [100]
+    frequencies = [1000.0, 5.0, 0.01]
+
+    assert buildCircuit(circuit, frequencies, *params,
+                        constants={})[0].replace(' ', '') == \
+        '([R([100],[1000.0,5.0,0.01])])'
+
 
 def test_RMSE():
     a = np.array([2 + 4*1j, 3 + 2*1j])


### PR DESCRIPTION
…g series and parallel strings are equal. Added test to cover this scenario. Addresses #128

Checking @lktsui test code:
```
from impedance.models.circuits import CustomCircuit
import numpy as np
test_circuit = CustomCircuit(circuit='R_1', initial_guess = [1.0,])
print(test_circuit)
frequency_range = np.linspace(0,100)
test_circuit.predict(frequency_range)
``` 

Returns:
```
Circuit string: R_1
Fit: False

Initial guesses:
    R_1 = 1.00e+00 [Ohm]

Simulating circuit based on initial parameters
[array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
        1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
        1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])]
```

Also returns expected results for circuits `'R1'`, `'C_1'` and `'L_1'`