### PR TITLE
Add kwargs to basinhopping

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,7 +3,7 @@ Frequently Asked Questions
 
 What method does impedance.py use for fitting equivalent circuit models?
 ------------------------------------------------------------------------
-Fitting is performed by non-linear least squares regression of
+By default, fitting is performed by non-linear least squares regression of
 the circuit model to impedance data via
 `curve_fit <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html>`_
 from the `scipy.optimize` package.[1]
@@ -23,6 +23,17 @@ problems and the Trust Region Reflective algorithm
 (:code:`method='trf'`) if bounds are provided. See `the SciPy documentation
 <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html>`_
 for more details and options.
+
+While the default method converges quickly and often yields acceptable fits,
+the results may be sensitive to the initial conditions.
+EIS fitting can be prone to this issue given the high dimensionality
+of typical equivalent circuit models.
+`Global optimization algorithms <https://en.wikipedia.org/wiki/Global_optimization>`_
+attempt to search the entire parameter landscape to minimize the error.
+By setting :code:`global_opt=True` in :code:`circuit_fit`, :code:`impedance.py` will use the
+`basinhopping <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>`_
+global optimization algorithm (also from the `scipy.optimize` package[1]) instead of :code:`curve_fit`,
+although the computational time may increase.
 
 [1] Virtanen, P., Gommers, R., Oliphant, T.E. et al.
 SciPy 1.0: fundamental algorithms for scientific computing in Python.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -32,8 +32,8 @@ of typical equivalent circuit models.
 attempt to search the entire parameter landscape to minimize the error.
 By setting :code:`global_opt=True` in :code:`circuit_fit`, :code:`impedance.py` will use the
 `basinhopping <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>`_
-global optimization algorithm (also from the `scipy.optimize` package[1]) instead of :code:`curve_fit`,
-although the computational time may increase.
+global optimization algorithm (also from the `scipy.optimize` package[1]) instead of :code:`curve_fit`.
+Note that the computational time may increase.
 
 [1] Virtanen, P., Gommers, R., Oliphant, T.E. et al.
 SciPy 1.0: fundamental algorithms for scientific computing in Python.

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -32,12 +32,12 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
     """ Main function for fitting an equivalent circuit to data.
 
     By default, this function uses `scipy.optimize.curve_fit
-    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit>`
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit>_`
     to fit the equivalent circuit. This function generally works well for
     simple circuits. However, the final results may be sensitive to
     the initial conditions for more complex circuits. In these cases,
     the `scipy.optimize.basinhopping
-    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>`)
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>_`)
     global optimization algorithm can be used to attempt a better fit.
 
     Parameters
@@ -139,7 +139,8 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
             return rmse(wrapCircuit(circuit, constants)(frequencies, *x),
                         np.hstack([Z.real, Z.imag]))
 
-        results = basinhopping(opt_function, x0=initial_guess, seed=seed)
+        results = basinhopping(opt_function, x0=initial_guess,
+                               seed=seed, **kwargs)
         popt = results.x
 
         # jacobian -> covariance

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -32,12 +32,12 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
     """ Main function for fitting an equivalent circuit to data.
 
     By default, this function uses `scipy.optimize.curve_fit
-    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit>_`
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html>`_
     to fit the equivalent circuit. This function generally works well for
     simple circuits. However, the final results may be sensitive to
     the initial conditions for more complex circuits. In these cases,
     the `scipy.optimize.basinhopping
-    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>_`)
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html>`_
     global optimization algorithm can be used to attempt a better fit.
 
     Parameters


### PR DESCRIPTION
Sorry for the messy PR! This is a brief follow up PR on #157. I forgot to pass the `kwargs` to `basinhopping`. If you could merge this and bump the version to 1.2.1, that would be great.

Also,
- Fix link typos in docstring (I was missing the underscore)
- Add FAQ section for global optimization