### PR TITLE
Basinhopping fixes and more

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -217,12 +217,6 @@ class BaseCircuit:
             for name, unit, param, conf in zip(names, units, params, confs):
                 to_print += '  {:>5} = {:.2e}'.format(name, param)
                 to_print += '  (+/- {:.2e}) [{}]\n'.format(conf, unit)
-        elif self._is_fit() and self.conf_ is None:
-            params = self.parameters_
-            to_print += '\nFit parameters (confidence calculations failed):\n'
-            for name, unit, param in zip(names, units, params):
-                to_print += '  {:>5} = {:.2e}'.format(name, param)
-                to_print += '  [{}]\n'.format(unit)
 
         return to_print
 

--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -211,7 +211,7 @@ class BaseCircuit:
         to_print += '\nInitial guesses:\n'
         for name, unit, param in zip(names, units, self.initial_guess):
             to_print += '  {:>5} = {:.2e} [{}]\n'.format(name, param, unit)
-        if self._is_fit() and self.conf_ is not None:
+        if self._is_fit():
             params, confs = self.parameters_, self.conf_
             to_print += '\nFit parameters:\n'
             for name, unit, param, conf in zip(names, units, params, confs):

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -25,9 +25,49 @@ def rmse(a, b):
     return np.linalg.norm(a - b) / np.sqrt(n)
 
 
-def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
-                bounds=None, bootstrap=False, global_opt=False, seed=0,
-                **kwargs):
+def set_default_bounds(circuit, constants={}):
+    """ This function sets default bounds for optimization.
+
+    set_default_bounds sets bounds of 0 and np.inf for all parameters,
+    except the CPE alpha which has an upper bound of 1.
+
+    Parameters
+    -----------------
+    circuit : string
+        String defining the equivalent circuit to be fit
+
+    constants : dictionary, optional
+        Parameters and their values to hold constant during fitting
+        (e.g. {"RO": 0.1}). Defaults to {}
+
+    Returns
+    ------------
+    bounds : 2-tuple of array_like
+        Lower and upper bounds on parameters.
+    """
+
+    # extract the elements from the circuit
+    extracted_elements = extract_circuit_elements(circuit)
+
+    # loop through bounds
+    lower_bounds, upper_bounds = [], []
+    for elem in extracted_elements:
+        raw_element = get_element_from_name(elem)
+        for i in range(check_and_eval(raw_element).num_params):
+            if elem in constants or elem + f'_{i}' in constants:
+                continue
+            if raw_element in ['CPE', 'La'] and i == 1:
+                upper_bounds.append(1)
+            else:
+                upper_bounds.append(np.inf)
+            lower_bounds.append(0)
+
+    bounds = ((lower_bounds), (upper_bounds))
+    return bounds
+
+
+def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
+                bounds=None, global_opt=False, **kwargs):
 
     """ Main function for fitting an equivalent circuit to data.
 
@@ -49,14 +89,14 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
         Impedances
 
     circuit : string
-        string defining the equivalent circuit to be fit
+        String defining the equivalent circuit to be fit
 
     initial_guess : list of floats
-        initial guesses for the fit parameters
+        Initial guesses for the fit parameters
 
-    constants : dictionary
-        parameters and their values to hold constant during fitting
-        (e.g. {"RO": 0.1})
+    constants : dictionary, optional
+        Parameters and their values to hold constant during fitting
+        (e.g. {"RO": 0.1}). Defaults to {}
 
     bounds : 2-tuple of array_like, optional
         Lower and upper bounds on parameters. Defaults to bounds on all
@@ -66,10 +106,6 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
     global_opt : bool, optional
         If global optimization should be used (uses the basinhopping
         algorithm). Defaults to False
-
-    seed : int, optional
-        Random seed, only used for the basinhopping algorithm.
-        Defaults to 0
 
     kwargs :
         Keyword arguments passed to scipy.optimize.curve_fit or
@@ -91,27 +127,24 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
     """
     Z = impedances
 
-    # extract the elements from the circuit
-    extracted_elements = extract_circuit_elements(circuit)
+    # pop kwargs passed in as kwargs
+    # this is useful if a user is trying different kwargs for fitting
+    if 'kwargs' in kwargs:
+        kwargs = kwargs['kwargs']
+
+    # remove kwargs that should not be passed to optimization functions
+    if 'bounds' in kwargs:
+        bounds = kwargs.pop('bounds')
+    if 'global_opt' in kwargs:
+        global_opt = kwargs.pop('global_opt')
 
     # set upper and lower bounds on a per-element basis
     if bounds is None:
-        lower_bounds, upper_bounds = [], []
-        for elem in extracted_elements:
-            raw_element = get_element_from_name(elem)
-            for i in range(check_and_eval(raw_element).num_params):
-                if elem in constants or elem + '_{}'.format(i) in constants:
-                    continue
-                if raw_element in ['CPE', 'La'] and i == 1:
-                    upper_bounds.append(1)
-                else:
-                    upper_bounds.append(np.inf)
-                lower_bounds.append(0)
-        bounds = ((lower_bounds), (upper_bounds))
+        bounds = set_default_bounds(circuit, constants=constants)
 
     if not global_opt:
         if 'maxfev' not in kwargs:
-            kwargs['maxfev'] = 100000
+            kwargs['maxfev'] = 1e5
         if 'ftol' not in kwargs:
             kwargs['ftol'] = 1e-13
 
@@ -122,6 +155,9 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
         perror = np.sqrt(np.diag(pcov))
 
     else:
+        if 'seed' not in kwargs:
+            kwargs['seed'] = 0
+
         def opt_function(x):
             """ Short function for basinhopping to optimize over.
             We want to minimize the RMSE between the fit and the data.
@@ -144,28 +180,29 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
             """
 
-            def __init__(self, xmax=upper_bounds, xmin=lower_bounds):
+            def __init__(self, xmax=bounds[1], xmin=bounds[0]):
                 self.xmax = np.array(xmax)
                 self.xmin = np.array(xmin)
 
             def __call__(self, **kwargs):
-                x = kwargs["x_new"]
+                x = kwargs['x_new']
                 tmax = bool(np.all(x <= self.xmax))
                 tmin = bool(np.all(x >= self.xmin))
                 return tmax and tmin
 
         basinhopping_bounds = BasinhoppingBounds()
-        results = basinhopping(opt_function, x0=initial_guess, seed=seed,
+        results = basinhopping(opt_function, x0=initial_guess,
                                accept_test=basinhopping_bounds, **kwargs)
         popt = results.x
 
         # jacobian -> covariance
         # https://stats.stackexchange.com/q/231868
-        jac = results.lowest_optimization_result["jac"][np.newaxis]
+        jac = results.lowest_optimization_result['jac'][np.newaxis]
         try:
-            perror = inv(np.dot(jac.T, jac)) * opt_function(popt) ** 2
-        except np.linalg.LinAlgError:
-            warnings.warn("Failed to compute perror")
+            pcov = inv(np.dot(jac.T, jac)) * opt_function(popt) ** 2
+            perror = np.sqrt(np.diag(pcov))
+        except (ValueError, np.linalg.LinAlgError):
+            warnings.warn('Failed to compute perror')
             perror = None
 
     return popt, perror
@@ -174,7 +211,8 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants,
 def wrapCircuit(circuit, constants):
     """ wraps function so we can pass the circuit string """
     def wrappedCircuit(frequencies, *parameters):
-        """ returns a stacked
+        """ returns a stacked array of real and imaginary impedance
+        components
 
         Parameters
         ----------

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -127,17 +127,6 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
     """
     Z = impedances
 
-    # pop kwargs passed in as kwargs
-    # this is useful if a user is trying different kwargs for fitting
-    if 'kwargs' in kwargs:
-        kwargs = kwargs['kwargs']
-
-    # remove kwargs that should not be passed to optimization functions
-    if 'bounds' in kwargs:
-        bounds = kwargs.pop('bounds')
-    if 'global_opt' in kwargs:
-        global_opt = kwargs.pop('global_opt')
-
     # set upper and lower bounds on a per-element basis
     if bounds is None:
         bounds = set_default_bounds(circuit, constants=constants)
@@ -180,9 +169,9 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.basinhopping.html
             """
 
-            def __init__(self, xmax=bounds[1], xmin=bounds[0]):
-                self.xmax = np.array(xmax)
+            def __init__(self, xmin, xmax):
                 self.xmin = np.array(xmin)
+                self.xmax = np.array(xmax)
 
             def __call__(self, **kwargs):
                 x = kwargs['x_new']
@@ -190,7 +179,7 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
                 tmin = bool(np.all(x >= self.xmin))
                 return tmax and tmin
 
-        basinhopping_bounds = BasinhoppingBounds()
+        basinhopping_bounds = BasinhoppingBounds(xmin=bounds[0], xmax=bounds[1])
         results = basinhopping(opt_function, x0=initial_guess,
                                accept_test=basinhopping_bounds, **kwargs)
         popt = results.x

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -29,7 +29,7 @@ def set_default_bounds(circuit, constants={}):
     """ This function sets default bounds for optimization.
 
     set_default_bounds sets bounds of 0 and np.inf for all parameters,
-    except the CPE alpha which has an upper bound of 1.
+    except the CPE and La alphas which have an upper bound of 1.
 
     Parameters
     -----------------

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -179,7 +179,8 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
                 tmin = bool(np.all(x >= self.xmin))
                 return tmax and tmin
 
-        basinhopping_bounds = BasinhoppingBounds(xmin=bounds[0], xmax=bounds[1])
+        basinhopping_bounds = BasinhoppingBounds(xmin=bounds[0],
+                                                 xmax=bounds[1])
         results = basinhopping(opt_function, x0=initial_guess,
                                accept_test=basinhopping_bounds, **kwargs)
         popt = results.x

--- a/impedance/tests/test_circuits.py
+++ b/impedance/tests/test_circuits.py
@@ -1,9 +1,11 @@
-from impedance.models.circuits import BaseCircuit, CustomCircuit, Randles
 import json
-import matplotlib.pyplot as plt
-import numpy as np
 import os
+
+import numpy as np
+import matplotlib.pyplot as plt
 import pytest
+
+from impedance.models.circuits import BaseCircuit, CustomCircuit, Randles
 
 # get example data
 data = np.genfromtxt(os.path.join("./data/",

--- a/impedance/tests/test_fitting.py
+++ b/impedance/tests/test_fitting.py
@@ -47,6 +47,20 @@ def test_set_default_bounds():
 
 def test_circuit_fit():
 
+    # Test trivial model (10 Ohm resistor)
+    circuit = 'R0'
+    initial_guess = [10]
+
+    results_simple = [10]
+
+    frequencies = np.array([10, 100, 1000])
+    Z_data = np.array([10, 10, 10]) # impedance is constant
+
+    assert np.allclose(circuit_fit(frequencies, Z_data, circuit,
+                                   initial_guess, constants={},
+                                   global_opt=True)[0],
+                       results_simple, rtol=1e-1)
+
     # Test example circuit from "Getting Started" page
     circuit = 'R0-p(R1,C1)-p(R2-Wo1,C2)'
     initial_guess = [.01, .01, 100, .01, .05, 100, 1]

--- a/impedance/tests/test_fitting.py
+++ b/impedance/tests/test_fitting.py
@@ -93,11 +93,11 @@ def test_circuit_fit():
 
     # Test global fitting on multiple seeds
     # All seeds should converge to the same parameter values
-    # seed = 0
+    # seed = 0 (default)
     assert np.allclose(circuit_fit(example_frequencies_filtered,
                                    Z_correct_filtered, circuit,
                                    initial_guess, constants={},
-                                   global_opt=True, seed=0)[0],
+                                   global_opt=True)[0],
                        results_global, rtol=1e-1)
 
     # seed = 0, with predefined bounds

--- a/impedance/tests/test_fitting.py
+++ b/impedance/tests/test_fitting.py
@@ -54,7 +54,7 @@ def test_circuit_fit():
     results_simple = [10]
 
     frequencies = np.array([10, 100, 1000])
-    Z_data = np.array([10, 10, 10]) # impedance is constant
+    Z_data = np.array([10, 10, 10])  # impedance is constant
 
     assert np.allclose(circuit_fit(frequencies, Z_data, circuit,
                                    initial_guess, constants={},


### PR DESCRIPTION
Apologies for the large PR, but I believe I have fully debugged `basinhopping` and made a few other tweaks as I went:

- Four bugs in the current `basinhopping` implementation
-- Properly sets `basinhopping` bounds if they are user-defined: `xmax=bounds[1], xmin=bounds[0]`
-- Catches both `ValueError` and `np.linalg.LinAlgError` as potential exceptions in calculating `perror`
-- Actually calculates `perror` instead of just `pcov`: `pcov = inv(np.dot(jac.T, jac)) * opt_function(popt) ** 2`; `perror = np.sqrt(np.diag(pcov))`
-- `print(circuit)` works even if calculating `perror` fails
- Adds tests for fitting with bounds and with weights
- Creates a function, `set_default_bounds`, adapted from `circuit_fit` (and added tests)
- Replaces `np.isclose(...).all()` with `np.allclose()` in the tests
- Adds some `kwarg` handling to `circuit_fit`
- Makes `seed` a `kwarg` instead of an optional arg, and makes `constants` an optional arg
- Minor wording changes and single-quote standardization

Let me know if you have any questions -- also happy to split this up if it's too much for one PR. I may have submitted the initial `basinhopping` PRs a bit prematurely, but I'm quite confident in its bug-free performance now.