### PR TITLE
add `CITATION.cff` to repo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use impedance.py in published work, please consider citing https://joss.theoj.org/papers/10.21105/joss.02349 as shown below"
+preferred-citation:
+  type: article
+  doi: 10.21105/joss.02349
+  url: https://doi.org/10.21105/joss.02349
+  year: 2020
+  publisher: The Open Journal
+  volume: 5
+  number: 52
+  pages: 2349
+  authors:
+    - family-names: Murbach
+      given-names: Matthew
+      orcid: http://orcid.org/0000-0002-6583-5995
+    - family-names: Gerwe
+      given-names: Brian
+      orcid: http://orcid.org/0000-0002-1184-8483
+    - family-names: Dawson-Elli
+      given-names: Neal
+      orcid: http://orcid.org/0000-0003-4559-7309
+    - family-names: Tsui
+      given-names: Lok-kun
+      orcid: http://orcid.org/0000-0001-7381-0686
+  title: "impedance.py: A Python package for electrochemical impedance analysis"
+  journal: Journal of Open Source Software


### PR DESCRIPTION
Hi all,

I quickly put this together for #173. If you are all interested in this, I'd love to make sure I get the citation correct. A sample of what it looks like can be seen on [my fork](https://github.com/hkennyv/impedance.py) under the repository description and license.

Currently, this `CITATION.cff` produces the following:

**APA citation**

```
Murbach, M., Gerwe, B., Dawson-Elli, N., & Tsui, L. impedance.py: A Python package for electrochemical impedance analysis. Journal of Open Source Software, 5(). https://doi.org/10.21105/joss.02349
```

**BibTeX citation**

```
@article{Murbach_impedance.py_A_Python,
author = {Murbach, Matthew and Gerwe, Brian and Dawson-Elli, Neal and Tsui, Lok-kun},
doi = {10.21105/joss.02349},
journal = {Journal of Open Source Software},
title = {{impedance.py: A Python package for electrochemical impedance analysis}},
url = {https://doi.org/10.21105/joss.02349},
volume = {5}
}
```

Note: It seems to be slightly different than the one currently in the `README.md`.

More info on this feature can be found [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files). As I mentioned in the issue, this github feature is geared towards software citations, but you can set the JOSS article as the preferred citation too (as I've done in the PR).