### PR TITLE
Changed np.complex to just complex in the "fit" function

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -10,10 +10,9 @@ import warnings
 
 
 class BaseCircuit:
-    """Base class for equivalent circuit models"""
-
+    """ Base class for equivalent circuit models """
     def __init__(self, initial_guess=[], constants=None, name=None):
-        """Base constructor for any equivalent circuit model
+        """ Base constructor for any equivalent circuit model
 
         Parameters
         ----------
@@ -32,7 +31,7 @@ class BaseCircuit:
         initial_guess = list(filter(None, initial_guess))
         for i in initial_guess:
             if not isinstance(i, (float, int, np.int32, np.float64)):
-                raise TypeError(f"value {i} in initial_guess is not a number")
+                raise TypeError(f'value {i} in initial_guess is not a number')
 
         # initalize class attributes
         self.initial_guess = initial_guess
@@ -56,12 +55,11 @@ class BaseCircuit:
                     matches.append(value == other.__dict__[key])
             return np.array(matches).all()
         else:
-            raise TypeError("Comparing object is not of the same type.")
+            raise TypeError('Comparing object is not of the same type.')
 
-    def fit(
-        self, frequencies, impedance, bounds=None, weight_by_modulus=False, **kwargs
-    ):
-        """Fit the circuit model
+    def fit(self, frequencies, impedance, bounds=None,
+            weight_by_modulus=False, **kwargs):
+        """ Fit the circuit model
 
         Parameters
         ----------
@@ -99,54 +97,44 @@ class BaseCircuit:
         #    impedance and frequency match in length
 
         if not isinstance(frequencies, np.ndarray):
-            raise TypeError("frequencies is not of type np.ndarray")
-        if not (
-            np.issubdtype(frequencies.dtype, np.integer)
-            or np.issubdtype(frequencies.dtype, np.floating)
-        ):
-            raise TypeError(
-                "frequencies array should have a numeric "
-                + f"dtype (currently {frequencies.dtype})"
-            )
+            raise TypeError('frequencies is not of type np.ndarray')
+        if not (np.issubdtype(frequencies.dtype, np.integer) or
+                np.issubdtype(frequencies.dtype, np.floating)):
+            raise TypeError('frequencies array should have a numeric ' +
+                            f'dtype (currently {frequencies.dtype})')
         if not isinstance(impedance, np.ndarray):
-            raise TypeError("impedance is not of type np.ndarray")
-        if impedance.dtype != complex:
-            raise TypeError(
-                "impedance array should have a complex "
-                + f"dtype (currently {impedance.dtype})"
-            )
+            raise TypeError('impedance is not of type np.ndarray')
+        if impedance.dtype != np.complex:
+            raise TypeError('impedance array should have a complex ' +
+                            f'dtype (currently {impedance.dtype})')
         if len(frequencies) != len(impedance):
-            raise TypeError("length of frequencies and impedance do not match")
+            raise TypeError('length of frequencies and impedance do not match')
 
         if self.initial_guess != []:
-            parameters, conf = circuit_fit(
-                frequencies,
-                impedance,
-                self.circuit,
-                self.initial_guess,
-                constants=self.constants,
-                bounds=bounds,
-                weight_by_modulus=weight_by_modulus,
-                **kwargs,
-            )
+            parameters, conf = circuit_fit(frequencies, impedance,
+                                           self.circuit, self.initial_guess,
+                                           constants=self.constants,
+                                           bounds=bounds,
+                                           weight_by_modulus=weight_by_modulus,
+                                           **kwargs)
             self.parameters_ = parameters
             if conf is not None:
                 self.conf_ = conf
         else:
             # TODO auto calculate initial guesses
-            raise ValueError("no initial guess supplied")
+            raise ValueError('no initial guess supplied')
 
         return self
 
     def _is_fit(self):
-        """check if model has been fit (parameters_ is not None)"""
+        """ check if model has been fit (parameters_ is not None) """
         if self.parameters_ is not None:
             return True
         else:
             return False
 
     def predict(self, frequencies, use_initial=False):
-        """Predict impedance using an equivalent circuit model
+        """ Predict impedance using an equivalent circuit model
 
         Parameters
         ----------
@@ -162,48 +150,32 @@ class BaseCircuit:
             Predicted impedance
         """
         if not isinstance(frequencies, np.ndarray):
-            raise TypeError("frequencies is not of type np.ndarray")
-        if not (
-            np.issubdtype(frequencies.dtype, np.integer)
-            or np.issubdtype(frequencies.dtype, np.floating)
-        ):
-            raise TypeError(
-                "frequencies array should have a numeric "
-                + f"dtype (currently {frequencies.dtype})"
-            )
+            raise TypeError('frequencies is not of type np.ndarray')
+        if not (np.issubdtype(frequencies.dtype, np.integer) or
+                np.issubdtype(frequencies.dtype, np.floating)):
+            raise TypeError('frequencies array should have a numeric ' +
+                            f'dtype (currently {frequencies.dtype})')
 
         if self._is_fit() and not use_initial:
-            return eval(
-                buildCircuit(
-                    self.circuit,
-                    frequencies,
-                    *self.parameters_,
-                    constants=self.constants,
-                    eval_string="",
-                    index=0,
-                )[0],
-                circuit_elements,
-            )
+            return eval(buildCircuit(self.circuit, frequencies,
+                                     *self.parameters_,
+                                     constants=self.constants, eval_string='',
+                                     index=0)[0],
+                        circuit_elements)
         else:
             warnings.warn("Simulating circuit based on initial parameters")
-            return eval(
-                buildCircuit(
-                    self.circuit,
-                    frequencies,
-                    *self.initial_guess,
-                    constants=self.constants,
-                    eval_string="",
-                    index=0,
-                )[0],
-                circuit_elements,
-            )
+            return eval(buildCircuit(self.circuit, frequencies,
+                                     *self.initial_guess,
+                                     constants=self.constants, eval_string='',
+                                     index=0)[0],
+                        circuit_elements)
 
     def get_param_names(self):
-        """Converts circuit string to names and units"""
+        """ Converts circuit string to names and units """
 
         # parse the element names from the circuit string
-        names = self.circuit.replace("p", "").replace("(", "").replace(")", "")
-        names = names.replace(",", "-").replace(" ", "").split("-")
+        names = self.circuit.replace('p', '').replace('(', '').replace(')', '')
+        names = names.replace(',', '-').replace(' ', '').split('-')
 
         full_names, all_units = [], []
         for name in names:
@@ -212,7 +184,7 @@ class BaseCircuit:
             units = check_and_eval(elem).units
             if num_params > 1:
                 for j in range(num_params):
-                    full_name = "{}_{}".format(name, j)
+                    full_name = '{}_{}'.format(name, j)
                     if full_name not in self.constants.keys():
                         full_names.append(full_name)
                         all_units.append(units[j])
@@ -224,40 +196,40 @@ class BaseCircuit:
         return full_names, all_units
 
     def __str__(self):
-        """Defines the pretty printing of the circuit"""
+        """ Defines the pretty printing of the circuit"""
 
-        to_print = "\n"
+        to_print = '\n'
         if self.name is not None:
-            to_print += "Name: {}\n".format(self.name)
-        to_print += "Circuit string: {}\n".format(self.circuit)
+            to_print += 'Name: {}\n'.format(self.name)
+        to_print += 'Circuit string: {}\n'.format(self.circuit)
         to_print += "Fit: {}\n".format(self._is_fit())
 
         if len(self.constants) > 0:
-            to_print += "\nConstants:\n"
+            to_print += '\nConstants:\n'
             for name, value in self.constants.items():
                 elem = get_element_from_name(name)
                 units = check_and_eval(elem).units
-                if "_" in name:
-                    unit = units[int(name.split("_")[-1])]
+                if '_' in name:
+                    unit = units[int(name.split('_')[-1])]
                 else:
                     unit = units[0]
-                to_print += "  {:>5} = {:.2e} [{}]\n".format(name, value, unit)
+                to_print += '  {:>5} = {:.2e} [{}]\n'.format(name, value, unit)
 
         names, units = self.get_param_names()
-        to_print += "\nInitial guesses:\n"
+        to_print += '\nInitial guesses:\n'
         for name, unit, param in zip(names, units, self.initial_guess):
-            to_print += "  {:>5} = {:.2e} [{}]\n".format(name, param, unit)
+            to_print += '  {:>5} = {:.2e} [{}]\n'.format(name, param, unit)
         if self._is_fit():
             params, confs = self.parameters_, self.conf_
-            to_print += "\nFit parameters:\n"
+            to_print += '\nFit parameters:\n'
             for name, unit, param, conf in zip(names, units, params, confs):
-                to_print += "  {:>5} = {:.2e}".format(name, param)
-                to_print += "  (+/- {:.2e}) [{}]\n".format(conf, unit)
+                to_print += '  {:>5} = {:.2e}'.format(name, param)
+                to_print += '  (+/- {:.2e}) [{}]\n'.format(conf, unit)
 
         return to_print
 
-    def plot(self, ax=None, f_data=None, Z_data=None, kind="altair", **kwargs):
-        """visualizes the model and optional data as a nyquist,
+    def plot(self, ax=None, f_data=None, Z_data=None, kind='altair', **kwargs):
+        """ visualizes the model and optional data as a nyquist,
             bode, or altair (interactive) plots
 
         Parameters
@@ -285,12 +257,12 @@ class BaseCircuit:
             axes of the created nyquist plot
         """
 
-        if kind == "nyquist":
+        if kind == 'nyquist':
             if ax is None:
                 fig, ax = plt.subplots(figsize=(5, 5))
 
             if Z_data is not None:
-                ax = plot_nyquist(ax, Z_data, ls="", marker="s", **kwargs)
+                ax = plot_nyquist(ax, Z_data, ls='', marker='s', **kwargs)
 
             if self._is_fit():
                 if f_data is not None:
@@ -299,9 +271,9 @@ class BaseCircuit:
                     f_pred = np.logspace(5, -3)
 
                 Z_fit = self.predict(f_pred)
-                ax = plot_nyquist(ax, Z_fit, ls="-", marker="", **kwargs)
+                ax = plot_nyquist(ax, Z_fit, ls='-', marker='', **kwargs)
             return ax
-        elif kind == "bode":
+        elif kind == 'bode':
             if ax is None:
                 fig, ax = plt.subplots(nrows=2, figsize=(5, 5))
 
@@ -312,20 +284,19 @@ class BaseCircuit:
 
             if Z_data is not None:
                 if f_data is None:
-                    raise ValueError(
-                        "f_data must be specified if" + " Z_data for a Bode plot"
-                    )
-                ax = plot_bode(ax, f_data, Z_data, ls="", marker="s", **kwargs)
+                    raise ValueError('f_data must be specified if' +
+                                     ' Z_data for a Bode plot')
+                ax = plot_bode(ax, f_data, Z_data, ls='', marker='s', **kwargs)
 
             if self._is_fit():
                 Z_fit = self.predict(f_pred)
-                ax = plot_bode(ax, f_pred, Z_fit, ls="-", marker="", **kwargs)
+                ax = plot_bode(ax, f_pred, Z_fit, ls='-', marker='', **kwargs)
             return ax
-        elif kind == "altair":
+        elif kind == 'altair':
             plot_dict = {}
 
             if Z_data is not None and f_data is not None:
-                plot_dict["data"] = {"f": f_data, "Z": Z_data}
+                plot_dict['data'] = {'f': f_data, 'Z': Z_data}
 
             if self._is_fit():
                 if f_data is not None:
@@ -337,19 +308,17 @@ class BaseCircuit:
                 if self.name is not None:
                     name = self.name
                 else:
-                    name = "fit"
-                plot_dict[name] = {"f": f_pred, "Z": Z_fit, "fmt": "-"}
+                    name = 'fit'
+                plot_dict[name] = {'f': f_pred, 'Z': Z_fit, 'fmt': '-'}
 
             chart = plot_altair(plot_dict, **kwargs)
             return chart
         else:
-            raise ValueError(
-                "Kind must be one of 'altair',"
-                + f"'nyquist', or 'bode' (received {kind})"
-            )
+            raise ValueError("Kind must be one of 'altair'," +
+                             f"'nyquist', or 'bode' (received {kind})")
 
     def save(self, filepath):
-        """Exports a model to JSON
+        """ Exports a model to JSON
 
         Parameters
         ----------
@@ -366,29 +335,26 @@ class BaseCircuit:
             parameters_ = list(self.parameters_)
             model_conf_ = list(self.conf_)
 
-            data_dict = {
-                "Name": model_name,
-                "Circuit String": model_string,
-                "Initial Guess": initial_guess,
-                "Constants": self.constants,
-                "Fit": True,
-                "Parameters": parameters_,
-                "Confidence": model_conf_,
-            }
+            data_dict = {"Name": model_name,
+                         "Circuit String": model_string,
+                         "Initial Guess": initial_guess,
+                         "Constants": self.constants,
+                         "Fit": True,
+                         "Parameters": parameters_,
+                         "Confidence": model_conf_,
+                         }
         else:
-            data_dict = {
-                "Name": model_name,
-                "Circuit String": model_string,
-                "Initial Guess": initial_guess,
-                "Constants": self.constants,
-                "Fit": False,
-            }
+            data_dict = {"Name": model_name,
+                         "Circuit String": model_string,
+                         "Initial Guess": initial_guess,
+                         "Constants": self.constants,
+                         "Fit": False}
 
-        with open(filepath, "w") as f:
+        with open(filepath, 'w') as f:
             json.dump(data_dict, f)
 
     def load(self, filepath, fitted_as_initial=False):
-        """Imports a model from JSON
+        """ Imports a model from JSON
 
         Parameters
         ----------
@@ -403,7 +369,7 @@ class BaseCircuit:
             fitted parameters as a completed model
         """
 
-        json_data_file = open(filepath, "r")
+        json_data_file = open(filepath, 'r')
         json_data = json.load(json_data_file)
 
         model_name = json_data["Name"]
@@ -419,17 +385,16 @@ class BaseCircuit:
 
         if json_data["Fit"]:
             if fitted_as_initial:
-                self.initial_guess = np.array(json_data["Parameters"])
+                self.initial_guess = np.array(json_data['Parameters'])
             else:
                 self.parameters_ = np.array(json_data["Parameters"])
                 self.conf_ = np.array(json_data["Confidence"])
 
 
 class Randles(BaseCircuit):
-    """A Randles circuit model class"""
-
+    """ A Randles circuit model class """
     def __init__(self, CPE=False, **kwargs):
-        """Constructor for the Randles' circuit class
+        """ Constructor for the Randles' circuit class
 
         Parameters
         ----------
@@ -442,28 +407,26 @@ class Randles(BaseCircuit):
         super().__init__(**kwargs)
 
         if CPE:
-            self.name = "Randles w/ CPE"
-            self.circuit = "R0-p(R1-Wo1,CPE1)"
+            self.name = 'Randles w/ CPE'
+            self.circuit = 'R0-p(R1-Wo1,CPE1)'
         else:
-            self.name = "Randles"
-            self.circuit = "R0-p(R1-Wo1,C1)"
+            self.name = 'Randles'
+            self.circuit = 'R0-p(R1-Wo1,C1)'
 
         circuit_len = calculateCircuitLength(self.circuit)
 
         if len(self.initial_guess) + len(self.constants) != circuit_len:
-            raise ValueError(
-                "The number of initial guesses "
-                + f"({len(self.initial_guess)}) + "
-                + "the number of constants "
-                + f"({len(self.constants)})"
-                + " must be equal to "
-                + f"the circuit length ({circuit_len})"
-            )
+            raise ValueError('The number of initial guesses ' +
+                             f'({len(self.initial_guess)}) + ' +
+                             'the number of constants ' +
+                             f'({len(self.constants)})' +
+                             ' must be equal to ' +
+                             f'the circuit length ({circuit_len})')
 
 
 class CustomCircuit(BaseCircuit):
-    def __init__(self, circuit="", **kwargs):
-        """Constructor for a customizable equivalent circuit model
+    def __init__(self, circuit='', **kwargs):
+        """ Constructor for a customizable equivalent circuit model
 
         Parameters
         ----------
@@ -492,11 +455,9 @@ class CustomCircuit(BaseCircuit):
         circuit_len = calculateCircuitLength(self.circuit)
 
         if len(self.initial_guess) + len(self.constants) != circuit_len:
-            raise ValueError(
-                "The number of initial guesses "
-                + f"({len(self.initial_guess)}) + "
-                + "the number of constants "
-                + f"({len(self.constants)})"
-                + " must be equal to "
-                + f"the circuit length ({circuit_len})"
-            )
+            raise ValueError('The number of initial guesses ' +
+                             f'({len(self.initial_guess)}) + ' +
+                             'the number of constants ' +
+                             f'({len(self.constants)})' +
+                             ' must be equal to ' +
+                             f'the circuit length ({circuit_len})')

--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -104,7 +104,7 @@ class BaseCircuit:
                             f'dtype (currently {frequencies.dtype})')
         if not isinstance(impedance, np.ndarray):
             raise TypeError('impedance is not of type np.ndarray')
-        if impedance.dtype != np.complex:
+        if impedance.dtype != complex:
             raise TypeError('impedance array should have a complex ' +
                             f'dtype (currently {impedance.dtype})')
         if len(frequencies) != len(impedance):

--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -10,9 +10,10 @@ import warnings
 
 
 class BaseCircuit:
-    """ Base class for equivalent circuit models """
+    """Base class for equivalent circuit models"""
+
     def __init__(self, initial_guess=[], constants=None, name=None):
-        """ Base constructor for any equivalent circuit model
+        """Base constructor for any equivalent circuit model
 
         Parameters
         ----------
@@ -31,7 +32,7 @@ class BaseCircuit:
         initial_guess = list(filter(None, initial_guess))
         for i in initial_guess:
             if not isinstance(i, (float, int, np.int32, np.float64)):
-                raise TypeError(f'value {i} in initial_guess is not a number')
+                raise TypeError(f"value {i} in initial_guess is not a number")
 
         # initalize class attributes
         self.initial_guess = initial_guess
@@ -55,11 +56,12 @@ class BaseCircuit:
                     matches.append(value == other.__dict__[key])
             return np.array(matches).all()
         else:
-            raise TypeError('Comparing object is not of the same type.')
+            raise TypeError("Comparing object is not of the same type.")
 
-    def fit(self, frequencies, impedance, bounds=None,
-            weight_by_modulus=False, **kwargs):
-        """ Fit the circuit model
+    def fit(
+        self, frequencies, impedance, bounds=None, weight_by_modulus=False, **kwargs
+    ):
+        """Fit the circuit model
 
         Parameters
         ----------
@@ -97,44 +99,54 @@ class BaseCircuit:
         #    impedance and frequency match in length
 
         if not isinstance(frequencies, np.ndarray):
-            raise TypeError('frequencies is not of type np.ndarray')
-        if not (np.issubdtype(frequencies.dtype, np.integer) or
-                np.issubdtype(frequencies.dtype, np.floating)):
-            raise TypeError('frequencies array should have a numeric ' +
-                            f'dtype (currently {frequencies.dtype})')
+            raise TypeError("frequencies is not of type np.ndarray")
+        if not (
+            np.issubdtype(frequencies.dtype, np.integer)
+            or np.issubdtype(frequencies.dtype, np.floating)
+        ):
+            raise TypeError(
+                "frequencies array should have a numeric "
+                + f"dtype (currently {frequencies.dtype})"
+            )
         if not isinstance(impedance, np.ndarray):
-            raise TypeError('impedance is not of type np.ndarray')
-        if impedance.dtype != np.complex:
-            raise TypeError('impedance array should have a complex ' +
-                            f'dtype (currently {impedance.dtype})')
+            raise TypeError("impedance is not of type np.ndarray")
+        if impedance.dtype != complex:
+            raise TypeError(
+                "impedance array should have a complex "
+                + f"dtype (currently {impedance.dtype})"
+            )
         if len(frequencies) != len(impedance):
-            raise TypeError('length of frequencies and impedance do not match')
+            raise TypeError("length of frequencies and impedance do not match")
 
         if self.initial_guess != []:
-            parameters, conf = circuit_fit(frequencies, impedance,
-                                           self.circuit, self.initial_guess,
-                                           constants=self.constants,
-                                           bounds=bounds,
-                                           weight_by_modulus=weight_by_modulus,
-                                           **kwargs)
+            parameters, conf = circuit_fit(
+                frequencies,
+                impedance,
+                self.circuit,
+                self.initial_guess,
+                constants=self.constants,
+                bounds=bounds,
+                weight_by_modulus=weight_by_modulus,
+                **kwargs,
+            )
             self.parameters_ = parameters
             if conf is not None:
                 self.conf_ = conf
         else:
             # TODO auto calculate initial guesses
-            raise ValueError('no initial guess supplied')
+            raise ValueError("no initial guess supplied")
 
         return self
 
     def _is_fit(self):
-        """ check if model has been fit (parameters_ is not None) """
+        """check if model has been fit (parameters_ is not None)"""
         if self.parameters_ is not None:
             return True
         else:
             return False
 
     def predict(self, frequencies, use_initial=False):
-        """ Predict impedance using an equivalent circuit model
+        """Predict impedance using an equivalent circuit model
 
         Parameters
         ----------
@@ -150,32 +162,48 @@ class BaseCircuit:
             Predicted impedance
         """
         if not isinstance(frequencies, np.ndarray):
-            raise TypeError('frequencies is not of type np.ndarray')
-        if not (np.issubdtype(frequencies.dtype, np.integer) or
-                np.issubdtype(frequencies.dtype, np.floating)):
-            raise TypeError('frequencies array should have a numeric ' +
-                            f'dtype (currently {frequencies.dtype})')
+            raise TypeError("frequencies is not of type np.ndarray")
+        if not (
+            np.issubdtype(frequencies.dtype, np.integer)
+            or np.issubdtype(frequencies.dtype, np.floating)
+        ):
+            raise TypeError(
+                "frequencies array should have a numeric "
+                + f"dtype (currently {frequencies.dtype})"
+            )
 
         if self._is_fit() and not use_initial:
-            return eval(buildCircuit(self.circuit, frequencies,
-                                     *self.parameters_,
-                                     constants=self.constants, eval_string='',
-                                     index=0)[0],
-                        circuit_elements)
+            return eval(
+                buildCircuit(
+                    self.circuit,
+                    frequencies,
+                    *self.parameters_,
+                    constants=self.constants,
+                    eval_string="",
+                    index=0,
+                )[0],
+                circuit_elements,
+            )
         else:
             warnings.warn("Simulating circuit based on initial parameters")
-            return eval(buildCircuit(self.circuit, frequencies,
-                                     *self.initial_guess,
-                                     constants=self.constants, eval_string='',
-                                     index=0)[0],
-                        circuit_elements)
+            return eval(
+                buildCircuit(
+                    self.circuit,
+                    frequencies,
+                    *self.initial_guess,
+                    constants=self.constants,
+                    eval_string="",
+                    index=0,
+                )[0],
+                circuit_elements,
+            )
 
     def get_param_names(self):
-        """ Converts circuit string to names and units """
+        """Converts circuit string to names and units"""
 
         # parse the element names from the circuit string
-        names = self.circuit.replace('p', '').replace('(', '').replace(')', '')
-        names = names.replace(',', '-').replace(' ', '').split('-')
+        names = self.circuit.replace("p", "").replace("(", "").replace(")", "")
+        names = names.replace(",", "-").replace(" ", "").split("-")
 
         full_names, all_units = [], []
         for name in names:
@@ -184,7 +212,7 @@ class BaseCircuit:
             units = check_and_eval(elem).units
             if num_params > 1:
                 for j in range(num_params):
-                    full_name = '{}_{}'.format(name, j)
+                    full_name = "{}_{}".format(name, j)
                     if full_name not in self.constants.keys():
                         full_names.append(full_name)
                         all_units.append(units[j])
@@ -196,40 +224,40 @@ class BaseCircuit:
         return full_names, all_units
 
     def __str__(self):
-        """ Defines the pretty printing of the circuit"""
+        """Defines the pretty printing of the circuit"""
 
-        to_print = '\n'
+        to_print = "\n"
         if self.name is not None:
-            to_print += 'Name: {}\n'.format(self.name)
-        to_print += 'Circuit string: {}\n'.format(self.circuit)
+            to_print += "Name: {}\n".format(self.name)
+        to_print += "Circuit string: {}\n".format(self.circuit)
         to_print += "Fit: {}\n".format(self._is_fit())
 
         if len(self.constants) > 0:
-            to_print += '\nConstants:\n'
+            to_print += "\nConstants:\n"
             for name, value in self.constants.items():
                 elem = get_element_from_name(name)
                 units = check_and_eval(elem).units
-                if '_' in name:
-                    unit = units[int(name.split('_')[-1])]
+                if "_" in name:
+                    unit = units[int(name.split("_")[-1])]
                 else:
                     unit = units[0]
-                to_print += '  {:>5} = {:.2e} [{}]\n'.format(name, value, unit)
+                to_print += "  {:>5} = {:.2e} [{}]\n".format(name, value, unit)
 
         names, units = self.get_param_names()
-        to_print += '\nInitial guesses:\n'
+        to_print += "\nInitial guesses:\n"
         for name, unit, param in zip(names, units, self.initial_guess):
-            to_print += '  {:>5} = {:.2e} [{}]\n'.format(name, param, unit)
+            to_print += "  {:>5} = {:.2e} [{}]\n".format(name, param, unit)
         if self._is_fit():
             params, confs = self.parameters_, self.conf_
-            to_print += '\nFit parameters:\n'
+            to_print += "\nFit parameters:\n"
             for name, unit, param, conf in zip(names, units, params, confs):
-                to_print += '  {:>5} = {:.2e}'.format(name, param)
-                to_print += '  (+/- {:.2e}) [{}]\n'.format(conf, unit)
+                to_print += "  {:>5} = {:.2e}".format(name, param)
+                to_print += "  (+/- {:.2e}) [{}]\n".format(conf, unit)
 
         return to_print
 
-    def plot(self, ax=None, f_data=None, Z_data=None, kind='altair', **kwargs):
-        """ visualizes the model and optional data as a nyquist,
+    def plot(self, ax=None, f_data=None, Z_data=None, kind="altair", **kwargs):
+        """visualizes the model and optional data as a nyquist,
             bode, or altair (interactive) plots
 
         Parameters
@@ -257,12 +285,12 @@ class BaseCircuit:
             axes of the created nyquist plot
         """
 
-        if kind == 'nyquist':
+        if kind == "nyquist":
             if ax is None:
                 fig, ax = plt.subplots(figsize=(5, 5))
 
             if Z_data is not None:
-                ax = plot_nyquist(ax, Z_data, ls='', marker='s', **kwargs)
+                ax = plot_nyquist(ax, Z_data, ls="", marker="s", **kwargs)
 
             if self._is_fit():
                 if f_data is not None:
@@ -271,9 +299,9 @@ class BaseCircuit:
                     f_pred = np.logspace(5, -3)
 
                 Z_fit = self.predict(f_pred)
-                ax = plot_nyquist(ax, Z_fit, ls='-', marker='', **kwargs)
+                ax = plot_nyquist(ax, Z_fit, ls="-", marker="", **kwargs)
             return ax
-        elif kind == 'bode':
+        elif kind == "bode":
             if ax is None:
                 fig, ax = plt.subplots(nrows=2, figsize=(5, 5))
 
@@ -284,19 +312,20 @@ class BaseCircuit:
 
             if Z_data is not None:
                 if f_data is None:
-                    raise ValueError('f_data must be specified if' +
-                                     ' Z_data for a Bode plot')
-                ax = plot_bode(ax, f_data, Z_data, ls='', marker='s', **kwargs)
+                    raise ValueError(
+                        "f_data must be specified if" + " Z_data for a Bode plot"
+                    )
+                ax = plot_bode(ax, f_data, Z_data, ls="", marker="s", **kwargs)
 
             if self._is_fit():
                 Z_fit = self.predict(f_pred)
-                ax = plot_bode(ax, f_pred, Z_fit, ls='-', marker='', **kwargs)
+                ax = plot_bode(ax, f_pred, Z_fit, ls="-", marker="", **kwargs)
             return ax
-        elif kind == 'altair':
+        elif kind == "altair":
             plot_dict = {}
 
             if Z_data is not None and f_data is not None:
-                plot_dict['data'] = {'f': f_data, 'Z': Z_data}
+                plot_dict["data"] = {"f": f_data, "Z": Z_data}
 
             if self._is_fit():
                 if f_data is not None:
@@ -308,17 +337,19 @@ class BaseCircuit:
                 if self.name is not None:
                     name = self.name
                 else:
-                    name = 'fit'
-                plot_dict[name] = {'f': f_pred, 'Z': Z_fit, 'fmt': '-'}
+                    name = "fit"
+                plot_dict[name] = {"f": f_pred, "Z": Z_fit, "fmt": "-"}
 
             chart = plot_altair(plot_dict, **kwargs)
             return chart
         else:
-            raise ValueError("Kind must be one of 'altair'," +
-                             f"'nyquist', or 'bode' (received {kind})")
+            raise ValueError(
+                "Kind must be one of 'altair',"
+                + f"'nyquist', or 'bode' (received {kind})"
+            )
 
     def save(self, filepath):
-        """ Exports a model to JSON
+        """Exports a model to JSON
 
         Parameters
         ----------
@@ -335,26 +366,29 @@ class BaseCircuit:
             parameters_ = list(self.parameters_)
             model_conf_ = list(self.conf_)
 
-            data_dict = {"Name": model_name,
-                         "Circuit String": model_string,
-                         "Initial Guess": initial_guess,
-                         "Constants": self.constants,
-                         "Fit": True,
-                         "Parameters": parameters_,
-                         "Confidence": model_conf_,
-                         }
+            data_dict = {
+                "Name": model_name,
+                "Circuit String": model_string,
+                "Initial Guess": initial_guess,
+                "Constants": self.constants,
+                "Fit": True,
+                "Parameters": parameters_,
+                "Confidence": model_conf_,
+            }
         else:
-            data_dict = {"Name": model_name,
-                         "Circuit String": model_string,
-                         "Initial Guess": initial_guess,
-                         "Constants": self.constants,
-                         "Fit": False}
+            data_dict = {
+                "Name": model_name,
+                "Circuit String": model_string,
+                "Initial Guess": initial_guess,
+                "Constants": self.constants,
+                "Fit": False,
+            }
 
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             json.dump(data_dict, f)
 
     def load(self, filepath, fitted_as_initial=False):
-        """ Imports a model from JSON
+        """Imports a model from JSON
 
         Parameters
         ----------
@@ -369,7 +403,7 @@ class BaseCircuit:
             fitted parameters as a completed model
         """
 
-        json_data_file = open(filepath, 'r')
+        json_data_file = open(filepath, "r")
         json_data = json.load(json_data_file)
 
         model_name = json_data["Name"]
@@ -385,16 +419,17 @@ class BaseCircuit:
 
         if json_data["Fit"]:
             if fitted_as_initial:
-                self.initial_guess = np.array(json_data['Parameters'])
+                self.initial_guess = np.array(json_data["Parameters"])
             else:
                 self.parameters_ = np.array(json_data["Parameters"])
                 self.conf_ = np.array(json_data["Confidence"])
 
 
 class Randles(BaseCircuit):
-    """ A Randles circuit model class """
+    """A Randles circuit model class"""
+
     def __init__(self, CPE=False, **kwargs):
-        """ Constructor for the Randles' circuit class
+        """Constructor for the Randles' circuit class
 
         Parameters
         ----------
@@ -407,26 +442,28 @@ class Randles(BaseCircuit):
         super().__init__(**kwargs)
 
         if CPE:
-            self.name = 'Randles w/ CPE'
-            self.circuit = 'R0-p(R1-Wo1,CPE1)'
+            self.name = "Randles w/ CPE"
+            self.circuit = "R0-p(R1-Wo1,CPE1)"
         else:
-            self.name = 'Randles'
-            self.circuit = 'R0-p(R1-Wo1,C1)'
+            self.name = "Randles"
+            self.circuit = "R0-p(R1-Wo1,C1)"
 
         circuit_len = calculateCircuitLength(self.circuit)
 
         if len(self.initial_guess) + len(self.constants) != circuit_len:
-            raise ValueError('The number of initial guesses ' +
-                             f'({len(self.initial_guess)}) + ' +
-                             'the number of constants ' +
-                             f'({len(self.constants)})' +
-                             ' must be equal to ' +
-                             f'the circuit length ({circuit_len})')
+            raise ValueError(
+                "The number of initial guesses "
+                + f"({len(self.initial_guess)}) + "
+                + "the number of constants "
+                + f"({len(self.constants)})"
+                + " must be equal to "
+                + f"the circuit length ({circuit_len})"
+            )
 
 
 class CustomCircuit(BaseCircuit):
-    def __init__(self, circuit='', **kwargs):
-        """ Constructor for a customizable equivalent circuit model
+    def __init__(self, circuit="", **kwargs):
+        """Constructor for a customizable equivalent circuit model
 
         Parameters
         ----------
@@ -455,9 +492,11 @@ class CustomCircuit(BaseCircuit):
         circuit_len = calculateCircuitLength(self.circuit)
 
         if len(self.initial_guess) + len(self.constants) != circuit_len:
-            raise ValueError('The number of initial guesses ' +
-                             f'({len(self.initial_guess)}) + ' +
-                             'the number of constants ' +
-                             f'({len(self.constants)})' +
-                             ' must be equal to ' +
-                             f'the circuit length ({circuit_len})')
+            raise ValueError(
+                "The number of initial guesses "
+                + f"({len(self.initial_guess)}) + "
+                + "the number of constants "
+                + f"({len(self.constants)})"
+                + " must be equal to "
+                + f"the circuit length ({circuit_len})"
+            )

--- a/impedance/preprocessing.py
+++ b/impedance/preprocessing.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def readFile(filename, instrument=None):
-    """ A wrapper for reading in many common types of impedance files
+    """A wrapper for reading in many common types of impedance files
 
     Parameters
     ----------
@@ -24,29 +24,37 @@ def readFile(filename, instrument=None):
 
     """
 
-    supported_types = ['gamry', 'autolab', 'parstat', 'zplot', 'versastudio',
-                       'powersuite', 'biologic', 'chinstruments']
+    supported_types = [
+        "gamry",
+        "autolab",
+        "parstat",
+        "zplot",
+        "versastudio",
+        "powersuite",
+        "biologic",
+        "chinstruments",
+    ]
 
     if instrument is not None:
-        assert instrument in supported_types,\
-            '{} is not a supported instrument ({})'.format(instrument,
-                                                           supported_types)
+        assert (
+            instrument in supported_types
+        ), "{} is not a supported instrument ({})".format(instrument, supported_types)
 
-    if instrument == 'gamry':
+    if instrument == "gamry":
         f, Z = readGamry(filename)
-    elif instrument == 'autolab':
+    elif instrument == "autolab":
         f, Z = readAutolab(filename)
-    elif instrument == 'biologic':
+    elif instrument == "biologic":
         f, Z = readBioLogic(filename)
-    elif instrument == 'parstat':
+    elif instrument == "parstat":
         f, Z = readParstat(filename)
-    elif instrument == 'zplot':
+    elif instrument == "zplot":
         f, Z = readZPlot(filename)
-    elif instrument == 'versastudio':
+    elif instrument == "versastudio":
         f, Z = readVersaStudio(filename)
-    elif instrument == 'powersuite':
+    elif instrument == "powersuite":
         f, Z = readPowerSuite(filename)
-    elif instrument == 'chinstruments':
+    elif instrument == "chinstruments":
         f, Z = readCHInstruments(filename)
     elif instrument is None:
         f, Z = readCSV(filename)
@@ -55,7 +63,7 @@ def readFile(filename, instrument=None):
 
 
 def readGamry(filename):
-    """ function for reading the .DTA file from Gamry
+    """function for reading the .DTA file from Gamry
 
     Parameters
     ----------
@@ -71,24 +79,25 @@ def readGamry(filename):
 
     """
 
-    with open(filename, 'r', encoding='ISO-8859-1') as input_file:
+    with open(filename, "r", encoding="ISO-8859-1") as input_file:
         lines = input_file.readlines()
 
     end_line = 0
 
     for i, line in enumerate(lines):
-        if 'ZCURVE' in line:
+        if "ZCURVE" in line:
             start_line = i
-        if 'EXPERIMENTABORTED' in line:
+        if "EXPERIMENTABORTED" in line:
             end_line = i
 
     if end_line != 0:
-        raw_data = lines[start_line + 3:end_line]
+        raw_data = lines[start_line + 3 : end_line]
     else:
-        raw_data = lines[start_line + 3:]
+        raw_data = lines[start_line + 3 :]
 
     f, Z = [], []
     for line in raw_data:
+        line = line.replace(",", ".")
         each = line.split()
         f.append(float(each[2]))
         Z.append(complex(float(each[3]), float(each[4])))
@@ -97,7 +106,7 @@ def readGamry(filename):
 
 
 def readAutolab(filename):
-    """ function for reading comma-delimited files from Autolab
+    """function for reading comma-delimited files from Autolab
 
     Parameters
     ----------
@@ -113,17 +122,17 @@ def readAutolab(filename):
 
     """
 
-    with open(filename, 'r', encoding="utf8") as input_file:
+    with open(filename, "r", encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     for i, line in enumerate(lines):
-        if line.find('Freq') != -1:
+        if line.find("Freq") != -1:
             start_line = i
 
-    raw_data = lines[start_line+1:]
+    raw_data = lines[start_line + 1 :]
     f, Z = [], []
     for line in raw_data:
-        each = line.split(',')
+        each = line.split(",")
         f.append(float(each[0]))
         Z.append(complex(float(each[4]), float(each[5])))
 
@@ -131,24 +140,24 @@ def readAutolab(filename):
 
 
 def readBioLogic(filename):
-    """ function for reading the .mpt file from Biologic
-        EC-lab software
+    """function for reading the .mpt file from Biologic
+    EC-lab software
 
-        Parameters
-        ----------
-        filename: string
-            Filename of .mpt file to extract impedance data from
+    Parameters
+    ----------
+    filename: string
+        Filename of .mpt file to extract impedance data from
 
-        Returns
-        -------
-        frequencies : np.ndarray
-            Array of frequencies
-        impedance : np.ndarray of complex numbers
-            Array of complex impedances
+    Returns
+    -------
+    frequencies : np.ndarray
+        Array of frequencies
+    impedance : np.ndarray of complex numbers
+        Array of complex impedances
 
-        """
+    """
 
-    with open(filename, 'r', encoding="latin-1") as input_file:
+    with open(filename, "r", encoding="latin-1") as input_file:
         lines = input_file.readlines()
 
     header_line = lines[1]
@@ -157,13 +166,13 @@ def readBioLogic(filename):
     number_header_lines = int(header_line.split(":")[1])
 
     # find the freq and Z columns
-    headers = lines[number_header_lines-1].split('\t')
+    headers = lines[number_header_lines - 1].split("\t")
 
-    freq_cols = [o for o, h in enumerate(headers) if h == 'freq/Hz']
-    ReZ_cols = [o for o, h in enumerate(headers) if h == 'Re(Z)/Ohm']
-    ImZ_cols = [o for o, h in enumerate(headers) if h == '-Im(Z)/Ohm']
+    freq_cols = [o for o, h in enumerate(headers) if h == "freq/Hz"]
+    ReZ_cols = [o for o, h in enumerate(headers) if h == "Re(Z)/Ohm"]
+    ImZ_cols = [o for o, h in enumerate(headers) if h == "-Im(Z)/Ohm"]
 
-    col_heads = ['freq/Hz', 'Re(Z)/Ohm', '-Im(Z)/Ohm']
+    col_heads = ["freq/Hz", "Re(Z)/Ohm", "-Im(Z)/Ohm"]
     for cols, ch in zip([freq_cols, ReZ_cols, ImZ_cols], col_heads):
         assert len(cols) > 0, f'"{ch}" not found in column headers'
 
@@ -174,17 +183,17 @@ def readBioLogic(filename):
     raw_data = lines[number_header_lines:]
     f, Z = [], []
     for line in raw_data:
-        each = line.split('\t')
+        each = line.split("\t")
         f.append(float(each[freq_col]))
 
         # MPT data format saves the imaginary portion as -Im(Z) not Im(Z)
-        Z.append(complex(float(each[ReZ_col]), -1*float(each[ImZ_col])))
+        Z.append(complex(float(each[ReZ_col]), -1 * float(each[ImZ_col])))
 
     return np.array(f), np.array(Z)
 
 
 def readParstat(filename):
-    """ function for reading the .txt file from Parstat
+    """function for reading the .txt file from Parstat
 
     Parameters
     ----------
@@ -200,7 +209,7 @@ def readParstat(filename):
 
     """
 
-    with open(filename, 'r') as input_file:
+    with open(filename, "r") as input_file:
         lines = input_file.readlines()
 
     raw_data = lines[1:]
@@ -215,7 +224,7 @@ def readParstat(filename):
 
 
 def readVersaStudio(filename):
-    """ function for reading the .PAR file from VersaStudio
+    """function for reading the .PAR file from VersaStudio
 
     Parameters
     ----------
@@ -231,7 +240,8 @@ def readVersaStudio(filename):
 
     """
     from re import split
-    with open(filename, 'r', encoding="utf8") as input_file:
+
+    with open(filename, "r", encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     # List to track [segment index, segment start line, segment end line]
@@ -240,18 +250,16 @@ def readVersaStudio(filename):
     for i, line in enumerate(lines):
         if "Segments" in line:
             if not segments:
-                segments = [[int(j) for j in split(r'[=\n]', line)
-                            if j.isdigit()]]
+                segments = [[int(j) for j in split(r"[=\n]", line) if j.isdigit()]]
 
-            elif [int(j) for j in split(r'[=\n]', line) if j.isdigit()]:
-                segments.append([int(j) for j in split(r'[=\n]', line)
-                                if j.isdigit()])
+            elif [int(j) for j in split(r"[=\n]", line) if j.isdigit()]:
+                segments.append([int(j) for j in split(r"[=\n]", line) if j.isdigit()])
 
         if segments:
             for j in segments:
-                if '<Segment' + str(segments[j[0]][0]) + '>' in line:
+                if "<Segment" + str(segments[j[0]][0]) + ">" in line:
                     segments[j[0]].append(i)
-                if '</Segment' + str(segments[j[0]][0]) + '>' in line:
+                if "</Segment" + str(segments[j[0]][0]) + ">" in line:
                     segments[j[0]].append(i)
 
     # Started building for option of multiple segments,
@@ -269,11 +277,11 @@ def readVersaStudio(filename):
     #         f.append(float(each[9]))
     #         Z.append(complex(float(each[14]),float(each[15])))
 
-    raw_data = lines[segments[1][1]+4:segments[1][2]]
+    raw_data = lines[segments[1][1] + 4 : segments[1][2]]
     f, Z = [], []
 
     for line in raw_data:
-        each = line.split(',')
+        each = line.split(",")
         f.append(float(each[9]))
         Z.append(complex(float(each[14]), float(each[15])))
 
@@ -281,7 +289,7 @@ def readVersaStudio(filename):
 
 
 def readZPlot(filename):
-    """ function for reading the .z file from Scribner's ZPlot
+    """function for reading the .z file from Scribner's ZPlot
 
     Parameters
     ----------
@@ -297,7 +305,8 @@ def readZPlot(filename):
 
     """
     import re
-    with open(filename, 'r', encoding="utf8") as input_file:
+
+    with open(filename, "r", encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     for i, line in enumerate(lines):
@@ -309,21 +318,21 @@ def readZPlot(filename):
             head_line = i
 
     try:
-        raw_data = lines[start_line+1:]
+        raw_data = lines[start_line + 1 :]
     except UnboundLocalError:
-        raw_data = lines[head_line+1:]
+        raw_data = lines[head_line + 1 :]
 
     f, Z = [], []
     for line in raw_data:
         # Can use this approach if we don't mind importing re module
-        each = re.split('\t|, ', line)
+        each = re.split("\t|, ", line)
         f.append(float(each[0]))
         Z.append(complex(float(each[4]), float(each[5])))
     return np.array(f), np.array(Z)
 
 
 def readPowerSuite(filename):
-    """ function for reading the .txt file from Parstat
+    """function for reading the .txt file from Parstat
 
     Parameters
     ----------
@@ -339,14 +348,14 @@ def readPowerSuite(filename):
 
     """
 
-    with open(filename, 'r') as input_file:
+    with open(filename, "r") as input_file:
         lines = input_file.readlines()
 
     raw_data = lines[1:]
     f, Z = [], []
     for line in raw_data:
         if not line.isspace():
-            freq, z_re, z_im = line.split('\t')
+            freq, z_re, z_im = line.split("\t")
             f.append(float(freq))
             Z.append(complex(float(z_re), float(z_im)))
 
@@ -354,7 +363,7 @@ def readPowerSuite(filename):
 
 
 def readCHInstruments(filename):
-    """ function for reading the .txt file from CHInstruments
+    """function for reading the .txt file from CHInstruments
 
     Parameters
     ----------
@@ -370,20 +379,20 @@ def readCHInstruments(filename):
 
     """
 
-    with open(filename, 'r') as input_file:
+    with open(filename, "r") as input_file:
         lines = input_file.readlines()
 
     # Locate the line where the data lives
     for i, line in enumerate(lines):
-        if line.startswith('Freq/Hz'):
+        if line.startswith("Freq/Hz"):
             # CH instruments has an empty space b/w header
             # and start of data line
-            start_line = i+2
+            start_line = i + 2
 
     raw_data = lines[start_line:]
     f, Z = [], []
     for line in raw_data:
-        each = line.split(',')
+        each = line.split(",")
         f.append(float(each[0]))
         Z.append(complex(float(each[1]), float(each[2])))
 
@@ -391,7 +400,7 @@ def readCHInstruments(filename):
 
 
 def readCSV(filename):
-    """ function for reading plain csv files
+    """function for reading plain csv files
 
     Parameters
     ----------
@@ -407,16 +416,16 @@ def readCSV(filename):
         Array of complex impedances
 
     """
-    data = np.genfromtxt(filename, delimiter=',')
+    data = np.genfromtxt(filename, delimiter=",")
 
     f = data[:, 0]
-    Z = data[:, 1] + 1j*data[:, 2]
+    Z = data[:, 1] + 1j * data[:, 2]
 
     return f, Z
 
 
 def saveCSV(filename, frequencies, impedances, **kwargs):
-    """ saves frequencies and impedances to a csv
+    """saves frequencies and impedances to a csv
 
     Parameters
     ----------
@@ -429,18 +438,20 @@ def saveCSV(filename, frequencies, impedances, **kwargs):
     kwargs :
         Keyword arguments passed to np.savetxt
     """
-    if not filename.endswith('.csv'):
-        filename += '.csv'
+    if not filename.endswith(".csv"):
+        filename += ".csv"
 
-    data = np.vstack([frequencies,
-                      np.real(impedances),
-                      np.imag(impedances),
-                      ]).T
+    data = np.vstack(
+        [
+            frequencies,
+            np.real(impedances),
+            np.imag(impedances),
+        ]
+    ).T
 
-    header = 'freq,Re(Z),Im(Z)'
+    header = "freq,Re(Z),Im(Z)"
 
-    np.savetxt(filename, data, delimiter=',',
-               header=header, **kwargs)
+    np.savetxt(filename, data, delimiter=",", header=header, **kwargs)
 
 
 def ignoreBelowX(frequencies, Z):

--- a/impedance/preprocessing.py
+++ b/impedance/preprocessing.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def readFile(filename, instrument=None):
-    """A wrapper for reading in many common types of impedance files
+    """ A wrapper for reading in many common types of impedance files
 
     Parameters
     ----------
@@ -24,37 +24,29 @@ def readFile(filename, instrument=None):
 
     """
 
-    supported_types = [
-        "gamry",
-        "autolab",
-        "parstat",
-        "zplot",
-        "versastudio",
-        "powersuite",
-        "biologic",
-        "chinstruments",
-    ]
+    supported_types = ['gamry', 'autolab', 'parstat', 'zplot', 'versastudio',
+                       'powersuite', 'biologic', 'chinstruments']
 
     if instrument is not None:
-        assert (
-            instrument in supported_types
-        ), "{} is not a supported instrument ({})".format(instrument, supported_types)
+        assert instrument in supported_types,\
+            '{} is not a supported instrument ({})'.format(instrument,
+                                                           supported_types)
 
-    if instrument == "gamry":
+    if instrument == 'gamry':
         f, Z = readGamry(filename)
-    elif instrument == "autolab":
+    elif instrument == 'autolab':
         f, Z = readAutolab(filename)
-    elif instrument == "biologic":
+    elif instrument == 'biologic':
         f, Z = readBioLogic(filename)
-    elif instrument == "parstat":
+    elif instrument == 'parstat':
         f, Z = readParstat(filename)
-    elif instrument == "zplot":
+    elif instrument == 'zplot':
         f, Z = readZPlot(filename)
-    elif instrument == "versastudio":
+    elif instrument == 'versastudio':
         f, Z = readVersaStudio(filename)
-    elif instrument == "powersuite":
+    elif instrument == 'powersuite':
         f, Z = readPowerSuite(filename)
-    elif instrument == "chinstruments":
+    elif instrument == 'chinstruments':
         f, Z = readCHInstruments(filename)
     elif instrument is None:
         f, Z = readCSV(filename)
@@ -63,7 +55,7 @@ def readFile(filename, instrument=None):
 
 
 def readGamry(filename):
-    """function for reading the .DTA file from Gamry
+    """ function for reading the .DTA file from Gamry
 
     Parameters
     ----------
@@ -79,25 +71,24 @@ def readGamry(filename):
 
     """
 
-    with open(filename, "r", encoding="ISO-8859-1") as input_file:
+    with open(filename, 'r', encoding='ISO-8859-1') as input_file:
         lines = input_file.readlines()
 
     end_line = 0
 
     for i, line in enumerate(lines):
-        if "ZCURVE" in line:
+        if 'ZCURVE' in line:
             start_line = i
-        if "EXPERIMENTABORTED" in line:
+        if 'EXPERIMENTABORTED' in line:
             end_line = i
 
     if end_line != 0:
-        raw_data = lines[start_line + 3 : end_line]
+        raw_data = lines[start_line + 3:end_line]
     else:
-        raw_data = lines[start_line + 3 :]
+        raw_data = lines[start_line + 3:]
 
     f, Z = [], []
     for line in raw_data:
-        line = line.replace(",", ".")
         each = line.split()
         f.append(float(each[2]))
         Z.append(complex(float(each[3]), float(each[4])))
@@ -106,7 +97,7 @@ def readGamry(filename):
 
 
 def readAutolab(filename):
-    """function for reading comma-delimited files from Autolab
+    """ function for reading comma-delimited files from Autolab
 
     Parameters
     ----------
@@ -122,17 +113,17 @@ def readAutolab(filename):
 
     """
 
-    with open(filename, "r", encoding="utf8") as input_file:
+    with open(filename, 'r', encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     for i, line in enumerate(lines):
-        if line.find("Freq") != -1:
+        if line.find('Freq') != -1:
             start_line = i
 
-    raw_data = lines[start_line + 1 :]
+    raw_data = lines[start_line+1:]
     f, Z = [], []
     for line in raw_data:
-        each = line.split(",")
+        each = line.split(',')
         f.append(float(each[0]))
         Z.append(complex(float(each[4]), float(each[5])))
 
@@ -140,24 +131,24 @@ def readAutolab(filename):
 
 
 def readBioLogic(filename):
-    """function for reading the .mpt file from Biologic
-    EC-lab software
+    """ function for reading the .mpt file from Biologic
+        EC-lab software
 
-    Parameters
-    ----------
-    filename: string
-        Filename of .mpt file to extract impedance data from
+        Parameters
+        ----------
+        filename: string
+            Filename of .mpt file to extract impedance data from
 
-    Returns
-    -------
-    frequencies : np.ndarray
-        Array of frequencies
-    impedance : np.ndarray of complex numbers
-        Array of complex impedances
+        Returns
+        -------
+        frequencies : np.ndarray
+            Array of frequencies
+        impedance : np.ndarray of complex numbers
+            Array of complex impedances
 
-    """
+        """
 
-    with open(filename, "r", encoding="latin-1") as input_file:
+    with open(filename, 'r', encoding="latin-1") as input_file:
         lines = input_file.readlines()
 
     header_line = lines[1]
@@ -166,13 +157,13 @@ def readBioLogic(filename):
     number_header_lines = int(header_line.split(":")[1])
 
     # find the freq and Z columns
-    headers = lines[number_header_lines - 1].split("\t")
+    headers = lines[number_header_lines-1].split('\t')
 
-    freq_cols = [o for o, h in enumerate(headers) if h == "freq/Hz"]
-    ReZ_cols = [o for o, h in enumerate(headers) if h == "Re(Z)/Ohm"]
-    ImZ_cols = [o for o, h in enumerate(headers) if h == "-Im(Z)/Ohm"]
+    freq_cols = [o for o, h in enumerate(headers) if h == 'freq/Hz']
+    ReZ_cols = [o for o, h in enumerate(headers) if h == 'Re(Z)/Ohm']
+    ImZ_cols = [o for o, h in enumerate(headers) if h == '-Im(Z)/Ohm']
 
-    col_heads = ["freq/Hz", "Re(Z)/Ohm", "-Im(Z)/Ohm"]
+    col_heads = ['freq/Hz', 'Re(Z)/Ohm', '-Im(Z)/Ohm']
     for cols, ch in zip([freq_cols, ReZ_cols, ImZ_cols], col_heads):
         assert len(cols) > 0, f'"{ch}" not found in column headers'
 
@@ -183,17 +174,17 @@ def readBioLogic(filename):
     raw_data = lines[number_header_lines:]
     f, Z = [], []
     for line in raw_data:
-        each = line.split("\t")
+        each = line.split('\t')
         f.append(float(each[freq_col]))
 
         # MPT data format saves the imaginary portion as -Im(Z) not Im(Z)
-        Z.append(complex(float(each[ReZ_col]), -1 * float(each[ImZ_col])))
+        Z.append(complex(float(each[ReZ_col]), -1*float(each[ImZ_col])))
 
     return np.array(f), np.array(Z)
 
 
 def readParstat(filename):
-    """function for reading the .txt file from Parstat
+    """ function for reading the .txt file from Parstat
 
     Parameters
     ----------
@@ -209,7 +200,7 @@ def readParstat(filename):
 
     """
 
-    with open(filename, "r") as input_file:
+    with open(filename, 'r') as input_file:
         lines = input_file.readlines()
 
     raw_data = lines[1:]
@@ -224,7 +215,7 @@ def readParstat(filename):
 
 
 def readVersaStudio(filename):
-    """function for reading the .PAR file from VersaStudio
+    """ function for reading the .PAR file from VersaStudio
 
     Parameters
     ----------
@@ -240,8 +231,7 @@ def readVersaStudio(filename):
 
     """
     from re import split
-
-    with open(filename, "r", encoding="utf8") as input_file:
+    with open(filename, 'r', encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     # List to track [segment index, segment start line, segment end line]
@@ -250,16 +240,18 @@ def readVersaStudio(filename):
     for i, line in enumerate(lines):
         if "Segments" in line:
             if not segments:
-                segments = [[int(j) for j in split(r"[=\n]", line) if j.isdigit()]]
+                segments = [[int(j) for j in split(r'[=\n]', line)
+                            if j.isdigit()]]
 
-            elif [int(j) for j in split(r"[=\n]", line) if j.isdigit()]:
-                segments.append([int(j) for j in split(r"[=\n]", line) if j.isdigit()])
+            elif [int(j) for j in split(r'[=\n]', line) if j.isdigit()]:
+                segments.append([int(j) for j in split(r'[=\n]', line)
+                                if j.isdigit()])
 
         if segments:
             for j in segments:
-                if "<Segment" + str(segments[j[0]][0]) + ">" in line:
+                if '<Segment' + str(segments[j[0]][0]) + '>' in line:
                     segments[j[0]].append(i)
-                if "</Segment" + str(segments[j[0]][0]) + ">" in line:
+                if '</Segment' + str(segments[j[0]][0]) + '>' in line:
                     segments[j[0]].append(i)
 
     # Started building for option of multiple segments,
@@ -277,11 +269,11 @@ def readVersaStudio(filename):
     #         f.append(float(each[9]))
     #         Z.append(complex(float(each[14]),float(each[15])))
 
-    raw_data = lines[segments[1][1] + 4 : segments[1][2]]
+    raw_data = lines[segments[1][1]+4:segments[1][2]]
     f, Z = [], []
 
     for line in raw_data:
-        each = line.split(",")
+        each = line.split(',')
         f.append(float(each[9]))
         Z.append(complex(float(each[14]), float(each[15])))
 
@@ -289,7 +281,7 @@ def readVersaStudio(filename):
 
 
 def readZPlot(filename):
-    """function for reading the .z file from Scribner's ZPlot
+    """ function for reading the .z file from Scribner's ZPlot
 
     Parameters
     ----------
@@ -305,8 +297,7 @@ def readZPlot(filename):
 
     """
     import re
-
-    with open(filename, "r", encoding="utf8") as input_file:
+    with open(filename, 'r', encoding="utf8") as input_file:
         lines = input_file.readlines()
 
     for i, line in enumerate(lines):
@@ -318,21 +309,21 @@ def readZPlot(filename):
             head_line = i
 
     try:
-        raw_data = lines[start_line + 1 :]
+        raw_data = lines[start_line+1:]
     except UnboundLocalError:
-        raw_data = lines[head_line + 1 :]
+        raw_data = lines[head_line+1:]
 
     f, Z = [], []
     for line in raw_data:
         # Can use this approach if we don't mind importing re module
-        each = re.split("\t|, ", line)
+        each = re.split('\t|, ', line)
         f.append(float(each[0]))
         Z.append(complex(float(each[4]), float(each[5])))
     return np.array(f), np.array(Z)
 
 
 def readPowerSuite(filename):
-    """function for reading the .txt file from Parstat
+    """ function for reading the .txt file from Parstat
 
     Parameters
     ----------
@@ -348,14 +339,14 @@ def readPowerSuite(filename):
 
     """
 
-    with open(filename, "r") as input_file:
+    with open(filename, 'r') as input_file:
         lines = input_file.readlines()
 
     raw_data = lines[1:]
     f, Z = [], []
     for line in raw_data:
         if not line.isspace():
-            freq, z_re, z_im = line.split("\t")
+            freq, z_re, z_im = line.split('\t')
             f.append(float(freq))
             Z.append(complex(float(z_re), float(z_im)))
 
@@ -363,7 +354,7 @@ def readPowerSuite(filename):
 
 
 def readCHInstruments(filename):
-    """function for reading the .txt file from CHInstruments
+    """ function for reading the .txt file from CHInstruments
 
     Parameters
     ----------
@@ -379,20 +370,20 @@ def readCHInstruments(filename):
 
     """
 
-    with open(filename, "r") as input_file:
+    with open(filename, 'r') as input_file:
         lines = input_file.readlines()
 
     # Locate the line where the data lives
     for i, line in enumerate(lines):
-        if line.startswith("Freq/Hz"):
+        if line.startswith('Freq/Hz'):
             # CH instruments has an empty space b/w header
             # and start of data line
-            start_line = i + 2
+            start_line = i+2
 
     raw_data = lines[start_line:]
     f, Z = [], []
     for line in raw_data:
-        each = line.split(",")
+        each = line.split(',')
         f.append(float(each[0]))
         Z.append(complex(float(each[1]), float(each[2])))
 
@@ -400,7 +391,7 @@ def readCHInstruments(filename):
 
 
 def readCSV(filename):
-    """function for reading plain csv files
+    """ function for reading plain csv files
 
     Parameters
     ----------
@@ -416,16 +407,16 @@ def readCSV(filename):
         Array of complex impedances
 
     """
-    data = np.genfromtxt(filename, delimiter=",")
+    data = np.genfromtxt(filename, delimiter=',')
 
     f = data[:, 0]
-    Z = data[:, 1] + 1j * data[:, 2]
+    Z = data[:, 1] + 1j*data[:, 2]
 
     return f, Z
 
 
 def saveCSV(filename, frequencies, impedances, **kwargs):
-    """saves frequencies and impedances to a csv
+    """ saves frequencies and impedances to a csv
 
     Parameters
     ----------
@@ -438,20 +429,18 @@ def saveCSV(filename, frequencies, impedances, **kwargs):
     kwargs :
         Keyword arguments passed to np.savetxt
     """
-    if not filename.endswith(".csv"):
-        filename += ".csv"
+    if not filename.endswith('.csv'):
+        filename += '.csv'
 
-    data = np.vstack(
-        [
-            frequencies,
-            np.real(impedances),
-            np.imag(impedances),
-        ]
-    ).T
+    data = np.vstack([frequencies,
+                      np.real(impedances),
+                      np.imag(impedances),
+                      ]).T
 
-    header = "freq,Re(Z),Im(Z)"
+    header = 'freq,Re(Z),Im(Z)'
 
-    np.savetxt(filename, data, delimiter=",", header=header, **kwargs)
+    np.savetxt(filename, data, delimiter=',',
+               header=header, **kwargs)
 
 
 def ignoreBelowX(frequencies, Z):


### PR DESCRIPTION
Changed np.complex to just complex in the "fit" function to fix this warning:
DeprecationWarning: np.complex is a deprecated alias for the builtin complex. To silence this warning, use complex by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use np.complex128 here.
Before:
`if impedance.dtype != np.complex:
     raise TypeError(
         "impedance array should have a complex "
         + f"dtype (currently {impedance.dtype})"
     )`
After:
`if impedance.dtype != complex:
     raise TypeError(
         "impedance array should have a complex "
         + f"dtype (currently {impedance.dtype})"
     )`
