### PR TITLE
Plotting update and a bug fix

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -188,7 +188,7 @@ class BaseCircuit:
             for name, value in self.constants.items():
                 elem = get_element_from_name(name)
                 units = check_and_eval(elem).units
-                if '_' in name:
+                if '_' in name and len(units)>1:
                     unit = units[int(name.split('_')[-1])]
                 else:
                     unit = units[0]

--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -188,7 +188,7 @@ class BaseCircuit:
             for name, value in self.constants.items():
                 elem = get_element_from_name(name)
                 units = check_and_eval(elem).units
-                if '_' in name and len(units)>1:
+                if '_' in name and len(units) > 1 :
                     unit = units[int(name.split('_')[-1])]
                 else:
                     unit = units[0]

--- a/impedance/visualization.py
+++ b/impedance/visualization.py
@@ -69,7 +69,7 @@ def plot_nyquist(Z, scale=1, units='Ohms', fmt='.-', ax=None, labelsize=20, tick
     return ax
 
 
-def plot_bode(f, Z, scale=1, units='Ohms', fmt='.-', axes=None, **kwargs):
+def plot_bode(f, Z, scale=1, units='Ohms', fmt='.-', axes=None, labelsize=20, ticksize=14, **kwargs):
     """ Plots impedance as a Bode plot using matplotlib
 
         Parameters
@@ -109,16 +109,16 @@ def plot_bode(f, Z, scale=1, units='Ohms', fmt='.-', axes=None, **kwargs):
 
     # Set the y-axis labels
     ax_mag.set_ylabel(r'$|Z(\omega)|$ ' +
-                      '$[{}]$'.format(units), fontsize=20)
-    ax_phs.set_ylabel(r'$-\phi_Z(\omega)$ ' + r'$[^o]$', fontsize=20)
+                      '$[{}]$'.format(units), fontsize=labelsize)
+    ax_phs.set_ylabel(r'$-\phi_Z(\omega)$ ' + r'$[^o]$', fontsize=labelsize)
 
     for ax in axes:
         # Set the frequency axes title and make log scale
-        ax.set_xlabel('f [Hz]', fontsize=20)
+        ax.set_xlabel('f [Hz]', fontsize=labelsize)
         ax.set_xscale('log')
 
         # Make the tick labels larger
-        ax.tick_params(axis='both', which='major', labelsize=14)
+        ax.tick_params(axis='both', which='major', labelsize=ticksize)
 
         # Change the number of labels on each axis to five
         ax.locator_params(axis='y', nbins=5, tight=True)

--- a/impedance/visualization.py
+++ b/impedance/visualization.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 
-def plot_nyquist(Z, scale=1, units='Ohms', fmt='.-', ax=None, **kwargs):
+def plot_nyquist(Z, scale=1, units='Ohms', fmt='.-', ax=None, labelsize=20, ticksize=14, **kwargs):
     """ Plots impedance as a Nyquist plot using matplotlib
 
         Parameters
@@ -42,12 +42,12 @@ def plot_nyquist(Z, scale=1, units='Ohms', fmt='.-', ax=None, **kwargs):
 
     # Set the labels to -imaginary vs real
     ax.set_xlabel(r'$Z^{\prime}(\omega)$ ' +
-                  '$[{}]$'.format(units), fontsize=20)
+                  '$[{}]$'.format(units), fontsize=labelsize)
     ax.set_ylabel(r'$-Z^{\prime\prime}(\omega)$ ' +
-                  '$[{}]$'.format(units), fontsize=20)
+                  '$[{}]$'.format(units), fontsize=labelsize)
 
     # Make the tick labels larger
-    ax.tick_params(axis='both', which='major', labelsize=14)
+    ax.tick_params(axis='both', which='major', labelsize=ticksize)
 
     # Change the number of labels on each axis to five
     ax.locator_params(axis='x', nbins=5, tight=True)


### PR DESCRIPTION
When there are multiple Nyquist or bode plots, it would be better to change the font size of x and y labels and ticks to fit the figure area. So just added the option for change with the default value the same as previous settings.

for the circuits.py:
if there is a circuit like
```
customCircuit = CustomCircuit(initial_guess=[0.045,None,.1,0.8,None, .1,0.8,],constants = {'R_1':0.03, 'R_2':0.03},
                              circuit='R_0-p(R_1,CPE_1)-p(R_2,CPE_2)')
```
the --str-- method will raise error when print (customCircuit), but not for 
```
customCircuit = CustomCircuit(initial_guess=[0.045,None,.1,0.8,None, .1,0.8,],constants = {'R_1_0':0.03, 'R_2_0':0.03},
                              circuit='R_0-p(R_1,CPE_1)-p(R_2,CPE_2)')
```
the reason is related to the code :
```
if '_' in name:
                    unit = units[int(name.split('_')[-1])]
```
So i added a evaluation that only if the len(uinits)>1 to apply the code.
