### PR TITLE
Removes Python 3.6 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.6
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: 3.7
 
       - name: Install dependencies
         run: |
@@ -37,13 +37,13 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -58,7 +58,7 @@ jobs:
           pytest --cov=impedance .
 
       - name: Upload coverage to coveralls
-        if: matrix.python-version == 3.6 && github.repository == 'ECSHackWeek/impedance.py'
+        if: matrix.python-version == 3.7 && github.repository == 'ECSHackWeek/impedance.py'
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [Getting started with impedance.py](https://impedancepy.readthedocs.io/en/la
 
 impedance.py requires:
 
--   Python (>=3.6)
+-   Python (>=3.7)
 -   SciPy (>=1.0)
 -   NumPy (>=1.14)
 -   Matplotlib (>=3.0)

--- a/impedance/tests/test_circuits.py
+++ b/impedance/tests/test_circuits.py
@@ -72,7 +72,7 @@ def test_Randles():
 
     # compare with known impedance predictions
     assert np.isclose(randles.predict(np.array([10.0])),
-                      np.complex(0.0251618, -0.00601304))
+                      complex(0.0251618, -0.00601304))
 
     # check altair plotting with a fit circuit
     chart = randles.plot(f_data=f, Z_data=Z)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://impedancepy.readthedocs.io/en/latest/",
     packages=setuptools.find_packages(),
-    python_requires="~=3.6",
+    python_requires="~=3.7",
     install_requires=['altair>=3.0', 'matplotlib>=3.0',
                       'numpy>=1.14', 'scipy>=1.0'],
     classifiers=(


### PR DESCRIPTION
Remove 3.6; EOL was 2021-12-24

As a result the ubuntu-latest (22.04) doesn't support 3.6 versions https://github.com/actions/setup-python/issues/544