### PR TITLE
add build and push to pypi in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
@@ -62,3 +62,31 @@ jobs:
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-push:
+    name: Build and publish package to PyPI if tagged
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python3 setup.py sdist bdist_wheel
+
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Also publish distribution to PyPI if tagged
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-push:
-    name: Build and publish package to PyPI if tagged
+    name: Build and publish package to PyPI
     runs-on: ubuntu-latest
 
     steps:
@@ -77,6 +77,7 @@ jobs:
 
       - name: Build a binary wheel and a source tarball
         run: |
+          python3 -m pip install wheel
           python3 setup.py sdist bdist_wheel
 
       - name: Publish distribution to Test PyPI
@@ -85,7 +86,7 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
-      - name: Also publish distribution to PyPI if tagged
+      - name: Also publish distribution to PyPI (if tagged)
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI tests
+name: Run tests and build package
 on:
   pull_request:
   push:
@@ -31,6 +31,7 @@ jobs:
 
   tests:
     name: Run tests
+    needs: linting
     runs-on: ubuntu-latest
 
     strategy:
@@ -65,6 +66,7 @@ jobs:
 
   build-and-push:
     name: Build and publish package to PyPI
+    needs: [linting, tests]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,7 @@ jobs:
           python3 -m pip install wheel
           python3 setup.py sdist bdist_wheel
 
-      - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-
-      - name: Also publish distribution to PyPI (if tagged)
+      - name: Publish distribution to PyPI (if tagged)
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Adds jobs to the GitHub Actions workflow to build and push package to PyPI. Closes https://github.com/ECSHackWeek/impedance.py/issues/217