### PR TITLE
handles single element circuits

### DIFF
--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -323,7 +323,8 @@ def buildCircuit(circuit, frequencies, *parameters,
         eval_string += "p(["
         split = parallel
     elif series == parallel:
-        eval_string += "(["
+        if len(series) > 1:
+            eval_string += "(["
         split = series
 
     for i, elem in enumerate(split):
@@ -355,7 +356,8 @@ def buildCircuit(circuit, frequencies, *parameters,
             eval_string += new
 
         if i == len(split) - 1:
-            eval_string += '])'
+            if len(split) > 1:
+                eval_string += '])'
         else:
             eval_string += ','
 

--- a/impedance/tests/test_circuits.py
+++ b/impedance/tests/test_circuits.py
@@ -185,3 +185,11 @@ def test_CustomCircuit():
     # incorrect circuit element in circuit
     with pytest.raises(ValueError):
         custom_circuit = CustomCircuit('R0-NotAnElement', initial_guess=[1, 2])
+
+    # test single element circuit
+    initial_guess = [1]
+    custom_string = 'R0'
+    custom_circuit = CustomCircuit(initial_guess=initial_guess,
+                                   circuit=custom_string)
+    custom_circuit.fit([1, 2, 3], [4, 4, 4])
+    assert custom_circuit.parameters_[0] == 4


### PR DESCRIPTION
Basically, the issue was that single element circuits were getting wrapped in an extra ([ ... ]) before being evaluated. This adds checks to make sure the length is > 1 before adding those brackets.