### PR TITLE
update Axes.grid to support matplotlib >= 3.5

### DIFF
--- a/impedance/visualization.py
+++ b/impedance/visualization.py
@@ -55,7 +55,7 @@ def plot_nyquist(Z, scale=1, units='Ohms', fmt='.-', ax=None, labelsize=20,
     ax.locator_params(axis='y', nbins=5, tight=True)
 
     # Add a light grid
-    ax.grid(b=True, which='major', axis='both', alpha=.5)
+    ax.grid(visible=True, which='major', axis='both', alpha=.5)
 
     # Change axis units to 10**log10(scale) and resize the offset text
     limits = -np.log10(scale)
@@ -126,7 +126,7 @@ def plot_bode(f, Z, scale=1, units='Ohms', fmt='.-', axes=None, labelsize=20,
         ax.locator_params(axis='y', nbins=5, tight=True)
 
         # Add a light grid
-        ax.grid(b=True, which='major', axis='both', alpha=.5)
+        ax.grid(visible=True, which='major', axis='both', alpha=.5)
 
     # Change axis units to 10**log10(scale) and resize the offset text
     limits = -np.log10(scale)
@@ -323,7 +323,7 @@ def plot_residuals(ax, f, res_real, res_imag, fmt='.-', y_limits=(-5, 5),
     ax.locator_params(axis='y', nbins=4, tight=True)
 
     # Add a light grid
-    ax.grid(b=True, which='major', axis='both', alpha=.5)
+    ax.grid(visible=True, which='major', axis='both', alpha=.5)
     ax.legend(fontsize=14)
 
     ax.set_ylim(y_limits)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altair>=3.0
 coveralls==3.2.0
-matplotlib>=3.0
+matplotlib>=3.5
 numpy>=1.14
 numpydoc
 nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://impedancepy.readthedocs.io/en/latest/",
     packages=setuptools.find_packages(),
     python_requires="~=3.7",
-    install_requires=['altair>=3.0', 'matplotlib>=3.0',
+    install_requires=['altair>=3.0', 'matplotlib>=3.5',
                       'numpy>=1.14', 'scipy>=1.0'],
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
[Matplotlib deprecated the `ax.grid(b=True)` in favor of renaming to `visible` in version 3.5](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#the-first-parameter-of-axes-grid-and-axis-grid-has-been-renamed-to-visible ). In theory, we could just remove the `b=True` since ["it is assumed you want the grid on"](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.grid.html) if any other kwargs are supplied, but this PR renames `b` to `visible` (and bumps the required matplotlib version to >= 3.5) to keep things explicit. 

