### PR TITLE
store covariance matrix

### DIFF
--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -122,8 +122,8 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
     p_values : list of floats
         best fit parameters for specified equivalent circuit
 
-    p_errors : list of floats
-        one standard deviation error estimates for fit parameters
+    pcov : square matrix
+        covariance matrix error estimates for fit parameters
 
     Notes
     ---------
@@ -152,12 +152,6 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
         popt, pcov = curve_fit(wrapCircuit(circuit, constants), f,
                                np.hstack([Z.real, Z.imag]),
                                p0=initial_guess, bounds=bounds, **kwargs)
-
-        # Calculate one standard deviation error estimates for fit parameters,
-        # defined as the square root of the diagonal of the covariance matrix.
-        # https://stackoverflow.com/a/52275674/5144795
-        perror = np.sqrt(np.diag(pcov))
-
     else:
         if 'seed' not in kwargs:
             kwargs['seed'] = 0
@@ -206,14 +200,11 @@ def circuit_fit(frequencies, impedances, circuit, initial_guess, constants={},
             # jacobian -> covariance
             # https://stats.stackexchange.com/q/231868
             pcov = inv(np.dot(jac.T, jac)) * opt_function(popt) ** 2
-            # covariance -> perror (one standard deviation
-            # error estimates for fit parameters)
-            perror = np.sqrt(np.diag(pcov))
         except (ValueError, np.linalg.LinAlgError):
             warnings.warn('Failed to compute perror')
-            perror = None
+            pcov = None
 
-    return popt, perror
+    return popt, pcov
 
 
 def wrapCircuit(circuit, constants):


### PR DESCRIPTION
The covariance of a fit is often a nice thing to be able to analyze.  It seems a waste to compute it and then discard an interesting fraction of it.  This PR changes the `circuit_fit` function to return the covariance matrix and not just the sqrt of the diagonal.  It stores this in the `BaseCircuit` object where a user could get it easily if desired.  It doesn't change any other aspect of the `BaseCircuit`.  

The `circuit_fit` function does change its output interface in a non-backward-compatible manner.  I don't call `circuit_fit` directly so from my use cases this is a "drop-in" fix, but in true semantic versioning parlance this is a breaking change.  If there were a desire to have the outputs of `circuit_fit` be unchanged by default, but have the full covariance as an option that is possible.  And I'd be willing to make that change.