### PR TITLE
Add parameters property function to BaseCircuit class

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -371,6 +371,11 @@ class BaseCircuit:
                 self.parameters_ = np.array(json_data["Parameters"])
                 self.conf_ = np.array(json_data["Confidence"])
 
+    @property
+    def parameters(self):
+        """Returns the model parameters."""
+        return self.parameters_
+
 
 class Randles(BaseCircuit):
     """ A Randles circuit model class """


### PR DESCRIPTION
In issue #285, a user was looking for a way to obtain the circuit model parameters as an array. The suggested workaround of accessing the `parameters_` attribute directly is not very elegant since it is a private parameter. To circumvent this, I have added a property routine to the `BaseCircuit` class, so one can now access the model parameters by calling