### PR TITLE
Allow float input to BaseCircuit.predict function

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -133,7 +133,10 @@ class BaseCircuit:
         impedance: ndarray of dtype 'complex128'
             Predicted impedance at each frequency
         """
-        frequencies = np.array(frequencies, dtype=float)
+        frequencies = (
+            np.array([frequencies], dtype=float) if isinstance(frequencies, float)
+            else np.array(frequencies, dtype=float)
+        )
 
         if self._is_fit() and not use_initial:
             return eval(buildCircuit(self.circuit, frequencies,


### PR DESCRIPTION
I have made a small change to the BaseCircuit.predict function that now allows both floats and lists/arrays are inputs.
```python
frequencies = (
    np.array([frequencies], dtype=float) if isinstance(frequencies, float)
    else np.array(frequencies, dtype=float)
)
```

So now, one can predict impedances at a single frequency (say, 10.) by calling
```python
Z = <circuit object>.predict(10.)
```