### PR TITLE
Add pandas requirement, change numpy requirement to 1.22.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 altair>=3.0
 coveralls==3.2.0
 matplotlib>=3.5
-numpy>=1.14
+numpy>=1.22.4
+pandas
 pytest>=4.6
 pytest-cov
 scipy>=1.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires="~=3.7",
     install_requires=['altair>=3.0', 'matplotlib>=3.5',
-                      'numpy>=1.14', 'scipy>=1.0'],
+                      'numpy>=1.22.4', 'scipy>=1.0',
+                      'pandas'],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
PR intended to close #305.

Pandas requirement added both to requirements.txt and to setup.py. Changed numpy requirement to 1.22.4 because apparently that is the oldest version still supported by pandas, (see https://pandas.pydata.org/docs/getting_started/install.html#required-dependencies). Perhaps a required version should be specified for pandas, too?