### PR TITLE
Correction of La element acording to #312 and #286 issue

### DIFF
--- a/impedance/models/circuits/elements.py
+++ b/impedance/models/circuits/elements.py
@@ -232,7 +232,7 @@ def La(p, f):
     """
     omega = 2 * np.pi * np.array(f)
     L, alpha = p[0], p[1]
-    Z = (L * 1j * omega) ** alpha
+    Z = L * (1j * omega) ** alpha
     return Z
 
 


### PR DESCRIPTION
Correction of improperly implemented La element, previously reported in #312 and #286 issue. The error was due to the inclusion of the variable L in parentheses, which, according to the reference linked in the element description, should be outside the parentheses.