### PR TITLE
Fix issues with numpy in circuit string evaluation

### DIFF
--- a/impedance/models/circuits/elements.py
+++ b/impedance/models/circuits/elements.py
@@ -45,12 +45,6 @@ def element(num_params, units, overwrite=False):
             )
         else:
             circuit_elements[func.__name__] = wrapper
-        # Adding numpy to circuit_elements for proper evaluation with
-        # numpy>=2.0.0 because the scalar representation was changed.
-        # "Scalars are now printed as np.float64(3.0) rather than just 3.0."
-        # https://numpy.org/doc/2.0/release/2.0.0-notes.html
-        # #representation-of-numpy-scalars-changed
-        circuit_elements["np"] = np
 
         return wrapper
 

--- a/impedance/validation.py
+++ b/impedance/validation.py
@@ -265,14 +265,18 @@ def fit_linKK(f, ts, M, Z, fit_type='real', add_cap=False):
 
 def eval_linKK(elements, ts, f):
     """Builds a circuit of RC elements to be used in LinKK"""
-    circuit_string = f"s([R({[elements[0]]},{f.tolist()}),"
+    elements_list = elements.tolist()
+    ts_list = ts.tolist()
+    f_list = f.tolist()
 
-    for Rk, tk in zip(elements[1:], ts):
-        circuit_string += f"K({[Rk, tk]},{f.tolist()}),"
+    circuit_string = f"s([R({[elements_list[0]]},{f_list}),"
 
-    circuit_string += f"L({[elements[-1]]},{f.tolist()}),"
-    if elements.size == (ts.size + 3):
-        circuit_string += f"C({[1 / elements[-2]]},{f.tolist()}),"
+    for Rk, tk in zip(elements_list[1:], ts_list):
+        circuit_string += f"K({[Rk, tk]},{f_list}),"
+
+    circuit_string += f"L({[elements_list[-1]]},{f_list}),"
+    if len(elements_list) == (len(ts_list) + 3):
+        circuit_string += f"C({[1 / elements_list[-2]]},{f_list}),"
 
     circuit_string = circuit_string.strip(',')
     circuit_string += '])'


### PR DESCRIPTION
My previous attempt at fixing in #298 wasn't sufficient because it relied on an implicit evaluation of `@element` decorators at import time. This fix converts all scalars to pure Python floats before evaluation, removing any type prefix associated with numpy. 

This should fix what was originally brought up in #296, and later brought up in #318 and #319. It will supersede what is down in #313 and #317.

Hopefully this lays the issue to rest, and sorry for all the problems and delay in actually addressing this.

