### PR TITLE
update minimum python version to 3.10 to avoid EoL versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -40,13 +40,13 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ See [Getting started with impedance.py](https://impedancepy.readthedocs.io/en/la
 
 impedance.py requires:
 
--   Python (>=3.7)
+-   Python (>=3.10)
 -   SciPy (>=1.0)
 -   NumPy (>=1.22.4)
--   Matplotlib (>=3.0)
+-   Matplotlib (>=3.5)
 -   Altair (>=3.0)
 -   Pandas
 

--- a/impedance/models/circuits/elements.py
+++ b/impedance/models/circuits/elements.py
@@ -33,7 +33,6 @@ def element(num_params, units, overwrite=False):
         wrapper.__name__ = func.__name__
         wrapper.__doc__ = func.__doc__
 
-        global circuit_elements
         if func.__name__ in ["s", "p"]:
             raise ElementError("cannot redefine elements 's' (series)" +
                                "or 'p' (parallel)")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://impedancepy.readthedocs.io/en/latest/",
     packages=setuptools.find_packages(),
-    python_requires="~=3.8",
+    python_requires="~=3.10",
     install_requires=['altair>=3.0', 'matplotlib>=3.5',
                       'numpy>=1.22.4', 'scipy>=1.0',
                       'pandas'],


### PR DESCRIPTION
3.8 and 3.9 are past end of life so we shouldn't support them anymore. Update minimum Python version to 3.10 and update the GitHub actions workflow