### PR TITLE
Accelerate fitting by factor ~5

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -135,6 +135,7 @@ class BaseCircuit:
         """
         frequencies = np.array(frequencies, dtype=float)
 
+        circuit_elements["frequencies"] = frequencies
         if self._is_fit() and not use_initial:
             return eval(buildCircuit(self.circuit, frequencies,
                                      *self.parameters_,

--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -135,20 +135,20 @@ class BaseCircuit:
         """
         frequencies = np.array(frequencies, dtype=float)
 
-        circuit_elements["frequencies"] = frequencies
+        arg_dict = {**circuit_elements, "frequencies": frequencies}
         if self._is_fit() and not use_initial:
             return eval(buildCircuit(self.circuit, frequencies,
                                      *self.parameters_,
                                      constants=self.constants, eval_string='',
                                      index=0)[0],
-                        circuit_elements)
+                        arg_dict)
         else:
             warnings.warn("Simulating circuit based on initial parameters")
             return eval(buildCircuit(self.circuit, frequencies,
                                      *self.initial_guess,
                                      constants=self.constants, eval_string='',
                                      index=0)[0],
-                        circuit_elements)
+                        arg_dict)
 
     def get_param_names(self):
         """ Converts circuit string to names and units """

--- a/impedance/models/circuits/elements.py
+++ b/impedance/models/circuits/elements.py
@@ -92,7 +92,7 @@ def p(parallel):
 # populated by the element decorator -
 # this maps ex. 'R' to the function R to always give us a list of
 # active elements in any context
-circuit_elements = {"s": s, "p": p}
+circuit_elements = {"s": s, "p": p, "frequencies": np.array([1.])}
 
 
 @element(num_params=1, units=["Ohm"])

--- a/impedance/models/circuits/elements.py
+++ b/impedance/models/circuits/elements.py
@@ -92,7 +92,7 @@ def p(parallel):
 # populated by the element decorator -
 # this maps ex. 'R' to the function R to always give us a list of
 # active elements in any context
-circuit_elements = {"s": s, "p": p, "frequencies": np.array([1.])}
+circuit_elements = {"s": s, "p": p}
 
 
 @element(num_params=1, units=["Ohm"])

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -235,6 +235,7 @@ def wrapCircuit(circuit, constants):
 
         """
 
+        circuit_elements["frequencies"] = frequencies
         x = eval(buildCircuit(circuit, frequencies, *parameters,
                               constants=constants, eval_string='',
                               index=0)[0],
@@ -350,7 +351,7 @@ def buildCircuit(circuit, frequencies, *parameters,
                     index += 1
 
             param_string += str(param_list)
-            new = raw_elem + '(' + param_string + ',' + str(frequencies) + ')'
+            new = raw_elem + '(' + param_string + ', frequencies)'
             eval_string += new
 
         if i == len(split) - 1:

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -351,7 +351,7 @@ def buildCircuit(circuit, frequencies, *parameters,
                     index += 1
 
             param_string += str(param_list)
-            new = raw_elem + '(' + param_string + ', frequencies)'
+            new = raw_elem + '(' + param_string + ',frequencies)'
             eval_string += new
 
         if i == len(split) - 1:

--- a/impedance/models/circuits/fitting.py
+++ b/impedance/models/circuits/fitting.py
@@ -235,11 +235,11 @@ def wrapCircuit(circuit, constants):
 
         """
 
-        circuit_elements["frequencies"] = frequencies
+        arg_dict = {**circuit_elements, "frequencies": frequencies}
         x = eval(buildCircuit(circuit, frequencies, *parameters,
                               constants=constants, eval_string='',
                               index=0)[0],
-                 circuit_elements)
+                 arg_dict)
         y_real = np.real(x)
         y_imag = np.imag(x)
 
@@ -443,4 +443,6 @@ def check_and_eval(element):
         raise ValueError(f'{element} not in ' +
                          f'allowed elements ({allowed_elements})')
     else:
-        return eval(element, circuit_elements)
+        dummy_frequency_array = np.array([1.])
+        arg_dict = {**circuit_elements, "frequencies": dummy_frequency_array}
+        return eval(element, arg_dict)

--- a/impedance/tests/test_fitting.py
+++ b/impedance/tests/test_fitting.py
@@ -153,10 +153,10 @@ def test_buildCircuit():
 
     assert buildCircuit(circuit, frequencies, *params,
                         constants={})[0].replace(' ', '') == \
-        's([R([0.1],[1000.0,5.0,0.01]),' + \
-        'p([s([R([0.01],[1000.0,5.0,0.01]),' + \
-        'Wo([1.0,1000.0],[1000.0,5.0,0.01])]),' + \
-        'CPE([15.0,0.9],[1000.0,5.0,0.01])])])'
+        's([R([0.1],frequencies),' + \
+        'p([s([R([0.01],frequencies),' + \
+        'Wo([1.0,1000.0],frequencies)]),' + \
+        'CPE([15.0,0.9],frequencies)])])'
 
     # Test multiple parallel elements
     circuit = 'R0-p(C1,R1,R2)'
@@ -165,10 +165,10 @@ def test_buildCircuit():
 
     assert buildCircuit(circuit, frequencies, *params,
                         constants={})[0].replace(' ', '') == \
-        's([R([0.1],[1000.0,5.0,0.01]),' + \
-        'p([C([0.01],[1000.0,5.0,0.01]),' + \
-        'R([0.2],[1000.0,5.0,0.01]),' + \
-        'R([0.3],[1000.0,5.0,0.01])])])'
+        's([R([0.1],frequencies),' + \
+        'p([C([0.01],frequencies),' + \
+        'R([0.2],frequencies),' + \
+        'R([0.3],frequencies)])])'
 
     # Test nested parallel groups
     circuit = 'R0-p(p(R1, C1)-R2, C2)'
@@ -177,11 +177,11 @@ def test_buildCircuit():
 
     assert buildCircuit(circuit, frequencies, *params,
                         constants={})[0].replace(' ', '') == \
-        's([R([1],[1000.0,5.0,0.01]),' + \
-        'p([s([p([R([2],[1000.0,5.0,0.01]),' + \
-        'C([3],[1000.0,5.0,0.01])]),' + \
-        'R([4],[1000.0,5.0,0.01])]),' + \
-        'C([5],[1000.0,5.0,0.01])])])'
+        's([R([1],frequencies),' + \
+        'p([s([p([R([2],frequencies),' + \
+        'C([3],frequencies)]),' + \
+        'R([4],frequencies)]),' + \
+        'C([5],frequencies)])])'
 
     # Test parallel elements at beginning and end
     circuit = 'p(C1,R1)-p(C2,R2)'
@@ -190,10 +190,10 @@ def test_buildCircuit():
 
     assert buildCircuit(circuit, frequencies, *params,
                         constants={})[0].replace(' ', '') == \
-        's([p([C([0.1],[1000.0,5.0,0.01]),' + \
-        'R([0.01],[1000.0,5.0,0.01])]),' + \
-        'p([C([0.2],[1000.0,5.0,0.01]),' + \
-        'R([0.3],[1000.0,5.0,0.01])])])'
+        's([p([C([0.1],frequencies),' + \
+        'R([0.01],frequencies)]),' + \
+        'p([C([0.2],frequencies),' + \
+        'R([0.3],frequencies)])])'
 
     # Test single element circuit
     circuit = 'R1'
@@ -202,7 +202,7 @@ def test_buildCircuit():
 
     assert buildCircuit(circuit, frequencies, *params,
                         constants={})[0].replace(' ', '') == \
-        'R([100],[1000.0,5.0,0.01])'
+        'R([100],frequencies)'
 
 
 def test_RMSE():


### PR DESCRIPTION
In the evaluation of a circuit, the `frequencies` array was written out explicitly in the `eval_string`. Given large amounts of impedance data, this can slow down the fitting considerably.

I suggest in this PR as a small fix to write the variable `frequencies` as a placeholder in the `eval_string` and pass it to the `eval()` routine, together with the `circuit_elements` dict.

I tried this on the following minimal example:
```python
import numpy as np
import matplotlib.pyplot as plt
from impedance.models.circuits import CustomCircuit
import time

cc = CustomCircuit("p(R_1, C_1)-p(R_2, C_2)", initial_guess=[1., 1., 3., 100.])
freq = np.logspace(-6, 2, 10000)
Z_data = cc.predict(freq)
Z_data = Z_data + np.random.normal(scale=.01, size=freq.size) + 1j*np.random.normal(scale=.01, size=freq.size)

t0 = time.time()
cc.fit(freq, Z_data)
t1 = time.time()
print (f"Fit took {t1-t0:1.2f}s.")
```
In the old version, the fit took almost 3 seconds; with the suggested change, it took only 0.5 seconds. If a fit is slow anyway (e.g. because of poor parameter identifiability), this may make for a very noticeable difference.