### PR TITLE
Fix ValueError when refitting after load(fitted_as_initial=True)

### DIFF
--- a/impedance/models/circuits/circuits.py
+++ b/impedance/models/circuits/circuits.py
@@ -96,7 +96,7 @@ class BaseCircuit:
         if len(frequencies) != len(impedance):
             raise TypeError('length of frequencies and impedance do not match')
 
-        if self.initial_guess != []:
+        if len(self.initial_guess) != 0:
             parameters, conf = circuit_fit(frequencies, impedance,
                                            self.circuit, self.initial_guess,
                                            constants=self.constants,

--- a/impedance/tests/test_model_io.py
+++ b/impedance/tests/test_model_io.py
@@ -31,3 +31,29 @@ def test_model_io():
 
     fitted_template = CustomCircuit()
     fitted_template.load('test_io.json', fitted_as_initial=True)
+
+
+def test_refit_after_load_fitted_as_initial():
+    # Regression test for #310: loading a fitted model with
+    # fitted_as_initial=True stores initial_guess as a numpy array, which
+    # broke the subsequent ``fit`` call because the emptiness check compared
+    # the array against ``[]`` (raising a broadcasting ValueError).
+    data = np.genfromtxt(os.path.join(".", "data",
+                                      "exampleData.csv"), delimiter=',')
+    frequencies = data[:, 0]
+    Z = data[:, 1] + 1j * data[:, 2]
+
+    randles = CustomCircuit(initial_guess=[.01, .005, .1, .005, .1, .9,
+                                           .001, 200],
+                            circuit='R0-p(R1,C1)-p(R1,CPE1)-Wo1')
+    randles.fit(frequencies, Z)
+    randles.save('./test_io.json')
+
+    reloaded = CustomCircuit()
+    reloaded.load('./test_io.json', fitted_as_initial=True)
+    assert isinstance(reloaded.initial_guess, np.ndarray)
+
+    # Refitting must not raise; it previously failed with
+    # "operands could not be broadcast together with shapes (n,) (0,)"
+    reloaded.fit(frequencies, Z)
+    assert reloaded.parameters_ is not None


### PR DESCRIPTION
## Summary

Loading a previously-fitted model with `fitted_as_initial=True` and then refitting it on a new spectrum raises a `ValueError`, as reported in #310:

```
ValueError: operands could not be broadcast together with shapes (n,) (0,)
```

### Root cause

`BaseCircuit.load(..., fitted_as_initial=True)` stores the fitted parameters as a **numpy array**:

```python
self.initial_guess = np.array(json_data['Parameters'])
```

The subsequent `fit()` then checks emptiness with `if self.initial_guess != []:`. For a numpy array this is an element-wise comparison, which NumPy tries to broadcast against the empty list `[]` (shape `(0,)`) and raises the broadcasting error. (This matches the workaround noted in the issue thread — manually casting `initial_guess` back to a `list`.)

### Fix

Test for emptiness with `len(self.initial_guess) != 0` instead. This is robust whether `initial_guess` is a list (the construction-time type) or a numpy array (the post-load type), and preserves the existing behaviour for the empty case.

## Reproduction

```python
import numpy as np
from impedance.models.circuits import CustomCircuit

c = CustomCircuit('R0-p(R1,C1)', initial_guess=[90, 180, 2e-5])
c.fit(freqs, Z)
c.save('m.json')

c2 = CustomCircuit()
c2.load('m.json', fitted_as_initial=True)   # initial_guess is now an ndarray
c2.fit(freqs, Z)                            # -> ValueError before this fix
```

## Verification

Added a regression test `test_refit_after_load_fitted_as_initial` in `impedance/tests/test_model_io.py` that fits a model, saves it, reloads it with `fitted_as_initial=True`, and refits. It fails on the current code with the reported `(n,) (0,)` broadcasting error and passes with this fix. The existing `test_model_io` suite continues to pass.

Fixes #310.