### PR TITLE
fix: add numpy to eval globals in eval_linKK for numpy 2.x compatibility

### DIFF
--- a/impedance/validation.py
+++ b/impedance/validation.py
@@ -281,7 +281,7 @@ def eval_linKK(elements, ts, f):
     circuit_string = circuit_string.strip(',')
     circuit_string += '])'
 
-    return eval(circuit_string, circuit_elements)
+    return eval(circuit_string, {**circuit_elements, 'np': np})
 
 
 def residuals_linKK(elements, ts, Z, f, residuals='real'):


### PR DESCRIPTION
numpy 2.x changed scalar repr (e.g. np.float64(0.001) instead of 0.001), causing NameError when eval_linKK evaluated the generated circuit string in worker processes. Adding 'np': np to the eval globals dict resolves this.